### PR TITLE
updated pkceflow_login.py notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .ipynb_checkpoints
 
 _site
+__marimo__

--- a/notebooks/pkceflow_login.py
+++ b/notebooks/pkceflow_login.py
@@ -1,23 +1,101 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "anywidget==0.9.18",
+#     "js==1.0",
+#     "marimo",
+#     "nbformat==5.10.4",
+#     "requests==2.32.4",
+# ]
+# ///
+
 import marimo
 
-__generated_with = "0.11.26"
-app = marimo.App(width="medium")
+__generated_with = "0.14.7"
+
+app = marimo.App(
+    width="full",
+    auto_download=["ipynb", "html"],
+)
 
 
-@app.cell
-def _():
+####################
+# Helper Functions #
+####################
+@app.cell(hide_code=True)
+async def _():
+    # Helper Functions - click to view code
+    import json
+    import marimo as mo
+    from urllib.request import Request, urlopen
+
+    try:
+        import js
+        origin = js.eval("self.location?.origin")
+        print(f"WASM environment detected - origin: {origin}")
+        # Configure OAuth endpoints based on environment
+        if "localhost:8088" in origin:
+            # Local development with Cloudflare Pages
+            print("Environment: Local WASM with Cloudflare Pages")
+            oauth_config = {
+                "logout_url": f"{origin}/oauth/revoke",
+                "redirect_uri": f"{origin}/oauth/callback",
+                "token_url": f"{origin}/oauth/token"
+            }
+        elif "localhost" in origin:
+            # Local WASM without Cloudflare Pages
+            print("Environment: Local WASM (standard)")
+            origin = "https://auth.sandbox.marimo.app"
+            oauth_config = {
+                "logout_url": f"{origin}/oauth/revoke",
+                "redirect_uri": f"{origin}/oauth/sso-callback",
+                "token_url": f"{origin}/oauth/token"
+            }
+        else:
+            # Production WASM environment
+            print("Environment: Production WASM")
+            oauth_config = {
+                "logout_url": f"{origin}/oauth/revoke",
+                "redirect_uri": f"{origin}/oauth/sso-callback",
+                "token_url": f"{origin}/oauth/token"
+            }
+    except AttributeError:
+        # Running in Python environment (not WASM)
+        print("Environment: Local Python")
+        origin = "https://auth.sandbox.marimo.app"
+        oauth_config = {
+            "logout_url": f"{origin}/oauth/revoke",
+            "redirect_uri": f"{origin}/oauth/sso-callback",
+            "token_url": f"{origin}/oauth/token",
+            "proxy": "https://cors-anywhere.herokuapp.com/https://example.com"
+        }
+
+    # Debug OAuth config
+    for key, value in oauth_config.items():
+        print(f"{key}: {value}")
+
+    return json, mo, Request, urlopen, origin, oauth_config
+
+
+###############
+# Login Cells #
+###############
+@app.cell(hide_code=True)
+def _(oauth_config):
+    # Login to Cloudflare - click to view code
+    import requests  # noqa: F401 - required for moutils.oauth
     from moutils.oauth import PKCEFlow
 
     df = PKCEFlow(
         provider="cloudflare",
         client_id="ec85d9cd-ff12-4d96-a376-432dbcf0bbfc",
-        redirect_uri="https://auth.sandbox.marimo.app/oauth/sso-callback",
-        proxy="examples-api-proxy.staging.notebooks.cfdata.org", # Fallback proxy for WASM/browser environments
-        debug=True,
+        logout_url=oauth_config["logout_url"],
+        redirect_uri=oauth_config["redirect_uri"],
+        token_url=oauth_config["token_url"],
+        proxy=oauth_config["proxy"],
     )
-
     df
-    return PKCEFlow, df
+    return df
 
 
 @app.cell

--- a/src/moutils/oauth.py
+++ b/src/moutils/oauth.py
@@ -248,8 +248,12 @@ class DeviceFlow(anywidget.AnyWidget):
 
     def _handle_token_change(self, change: Dict[str, Any]) -> None:
         """Handle changes to the access_token property."""
-        if change["new"] and self.on_success:
+        if self.debug:
+            self._log(f"_handle_token_change called: change={change}, current status={self.status}")
+        if change["new"]:
             self._log("Access token received, calling success callback")
+            # Always update status to success to trigger UI update
+            self.status = "success"
             token_data: Dict[str, Union[str, List[str], int]] = {
                 "access_token": self.access_token,
                 "token_type": self.token_type,
@@ -257,15 +261,15 @@ class DeviceFlow(anywidget.AnyWidget):
                 "scopes": self.authorized_scopes,
                 "provider": self.provider,
             }
-
             if self.refresh_token_expires_in:
                 token_data["refresh_token_expires_in"] = self.refresh_token_expires_in
-
-            # Call success callback
-            self.on_success(token_data)
-
+            # Call success callback if provided
+            if self.on_success:
+                self.on_success(token_data)
             # Ensure we don't trigger another auth flow
             self.start_auth = False
+            # Store token data for persistence (this will be handled by JavaScript)
+            self._store_token_for_persistence()
 
     def _handle_error_change(self, change: Dict[str, Any]) -> None:
         """Handle changes to the error_message property."""
@@ -304,7 +308,14 @@ class DeviceFlow(anywidget.AnyWidget):
 
     def reset(self) -> None:
         """Reset the authentication state."""
-        self._log("Resetting authentication state")
+        if self.debug:
+            self._log(f"reset called. Current access_token={self.access_token}, status={self.status}")
+        # Store configuration properties that should persist
+        hostname = self.hostname
+        port = self.port
+        href = self.href
+        proxy = self.proxy
+        # Reset authentication state
         self.device_code = ""
         self.user_code = ""
         self.access_token = ""
@@ -315,6 +326,11 @@ class DeviceFlow(anywidget.AnyWidget):
         self.status = "not_started"
         self.error_message = ""
         self._expires_at = 0
+        # Restore configuration properties
+        self.hostname = hostname
+        self.port = port
+        self.href = href
+        self.proxy = proxy
 
     def start_device_flow(self) -> None:
         """Start the device flow authentication process."""
@@ -694,6 +710,8 @@ class DeviceFlow(anywidget.AnyWidget):
         finally:
             # Reset all authentication state
             self.reset()
+            # Clear token expiration to trigger JavaScript cleanup
+            self.token_expires_in = 0
             # Update status to not_started
             self.status = "not_started"
             self._log("Logout complete")
@@ -737,6 +755,7 @@ class PKCEFlow(anywidget.AnyWidget):
     port = traitlets.Unicode("").tag(sync=True)
     proxy = traitlets.Unicode("").tag(sync=True)
     href = traitlets.Unicode("").tag(sync=True)
+    use_new_tab = traitlets.Bool(True).tag(sync=True)
 
     # PKCE state
     code_verifier = traitlets.Unicode("").tag(sync=True)
@@ -761,6 +780,9 @@ class PKCEFlow(anywidget.AnyWidget):
     start_auth = traitlets.Bool(False).tag(sync=True)
     handle_callback = traitlets.Unicode("").tag(sync=True)
     logout_requested = traitlets.Bool(False).tag(sync=True)
+    
+    # Token persistence
+    token_expires_in = traitlets.Int(0).tag(sync=True)
 
     # Events
     on_success = None
@@ -778,6 +800,7 @@ class PKCEFlow(anywidget.AnyWidget):
         scopes: Optional[str] = None,
         logout_url: Optional[str] = None,
         proxy: Optional[str] = None,
+        use_new_tab: Optional[bool] = None,
         additional_state: Optional[Callable[[], Dict[str, Any]]] = None,
         on_success: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_error: Optional[Callable[[str], None]] = None,
@@ -795,6 +818,7 @@ class PKCEFlow(anywidget.AnyWidget):
             scopes: Space-separated list of OAuth scopes to request
             logout_url: URL to revoke tokens (defaults to provider default)
             proxy: Proxy URL to use for HTTP requests (e.g., "https://proxy.example.com")
+            use_new_tab: Whether to open the authorization URL in a new tab (True) or same tab (False)
             on_success: Callback function when authentication succeeds
             on_error: Callback function when authentication fails
             debug: Whether to show debug information
@@ -863,6 +887,7 @@ class PKCEFlow(anywidget.AnyWidget):
             scopes=scopes,
             logout_url=logout_url,
             proxy=proxy or "",
+            use_new_tab=use_new_tab,
         )
 
     def _log(self, message: str) -> None:
@@ -1014,8 +1039,12 @@ class PKCEFlow(anywidget.AnyWidget):
 
     def _handle_token_change(self, change: Dict[str, Any]) -> None:
         """Handle changes to the access_token property."""
-        if change["new"] and self.on_success:
+        if self.debug:
+            self._log(f"_handle_token_change called: change={change}, current status={self.status}")
+        if change["new"]:
             self._log("Access token received, calling success callback")
+            # Always update status to success to trigger UI update
+            self.status = "success"
             token_data: Dict[str, Union[str, List[str], int]] = {
                 "access_token": self.access_token,
                 "token_type": self.token_type,
@@ -1023,15 +1052,31 @@ class PKCEFlow(anywidget.AnyWidget):
                 "scopes": self.authorized_scopes,
                 "provider": self.provider,
             }
-
             if self.refresh_token_expires_in:
                 token_data["refresh_token_expires_in"] = self.refresh_token_expires_in
-
-            # Call success callback
-            self.on_success(token_data)
-
+            # Call success callback if provided
+            if self.on_success:
+                self.on_success(token_data)
             # Ensure we don't trigger another auth flow
             self.start_auth = False
+            # Store token data for persistence (this will be handled by JavaScript)
+            self._store_token_for_persistence()
+
+    def _store_token_for_persistence(self) -> None:
+        """Store token data in the widget for JavaScript persistence."""
+        if self.debug:
+            self._log("Storing token data for persistence")
+        
+        # Set the token expiration time to trigger JavaScript storage
+        # Most OAuth tokens expire in 1 hour (3600 seconds) if not specified
+        expires_in = 3600  # Default to 1 hour
+        
+        # Try to get expiration from token response if available
+        # This would need to be set when the token is received
+        if hasattr(self, '_token_expires_in') and self._token_expires_in:
+            expires_in = self._token_expires_in
+        
+        self.token_expires_in = expires_in
 
     def _handle_error_change(self, change: Dict[str, Any]) -> None:
         """Handle changes to the error_message property."""
@@ -1108,6 +1153,9 @@ class PKCEFlow(anywidget.AnyWidget):
                 self.refresh_token_expires_in = token_response.get(
                     "refresh_token_expires_in", 0
                 )
+                
+                # Store token expiration time for persistence
+                self._token_expires_in = token_response.get("expires_in", 3600)
 
                 # Parse scopes
                 if "scope" in token_response:
@@ -1118,6 +1166,9 @@ class PKCEFlow(anywidget.AnyWidget):
                 self.status = "success"
                 self.start_auth = False
                 self._log("Authentication successful")
+                
+                # Store token data for persistence
+                self._store_token_for_persistence()
                 return
 
             # Handle errors
@@ -1138,14 +1189,13 @@ class PKCEFlow(anywidget.AnyWidget):
 
     def reset(self) -> None:
         """Reset the authentication state."""
-        self._log("Resetting authentication state")
-        
+        if self.debug:
+            self._log(f"reset called. Current access_token={self.access_token}, status={self.status}")
         # Store configuration properties that should persist
         hostname = self.hostname
         port = self.port
         href = self.href
         proxy = self.proxy
-        
         # Reset authentication state
         self.code_verifier = ""
         self.code_challenge = ""
@@ -1155,10 +1205,10 @@ class PKCEFlow(anywidget.AnyWidget):
         self.token_type = ""
         self.refresh_token = ""
         self.refresh_token_expires_in = 0
+        self.token_expires_in = 0
         self.authorized_scopes = []
         self.status = "not_started"
         self.error_message = ""
-        
         # Restore configuration properties
         self.hostname = hostname
         self.port = port
@@ -1438,6 +1488,8 @@ class PKCEFlow(anywidget.AnyWidget):
         finally:
             # Reset all authentication state
             self.reset()
+            # Clear token expiration to trigger JavaScript cleanup
+            self.token_expires_in = 0
             # Update status to not_started
             self.status = "not_started"
             self._log("Logout complete")

--- a/src/moutils/oauth.py
+++ b/src/moutils/oauth.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, TypedDict, Union, cast
 import urllib.parse
 import urllib.request
 import urllib.error
+from collections import OrderedDict
 
 import anywidget
 import traitlets
@@ -917,11 +918,11 @@ class PKCEFlow(anywidget.AnyWidget):
                     f"Fallback hostname for sandbox_id: {sandbox_id}"
                 )
 
-        state = {
-            "href": self.href,
-            "nonce": f"{secrets.token_urlsafe(16)}.{secrets.token_urlsafe(8)}",
-            "sandbox_id": sandbox_id, 
-        }
+        state = OrderedDict([
+            ("sandbox_id", sandbox_id),
+            ("href", self.href),
+            ("nonce", f"{secrets.token_urlsafe(16)}.{secrets.token_urlsafe(8)}"),
+        ])
         if self.additional_state is not None:
             state.update(self.additional_state())
 
@@ -1138,6 +1139,14 @@ class PKCEFlow(anywidget.AnyWidget):
     def reset(self) -> None:
         """Reset the authentication state."""
         self._log("Resetting authentication state")
+        
+        # Store configuration properties that should persist
+        hostname = self.hostname
+        port = self.port
+        href = self.href
+        proxy = self.proxy
+        
+        # Reset authentication state
         self.code_verifier = ""
         self.code_challenge = ""
         self.state = ""
@@ -1149,6 +1158,12 @@ class PKCEFlow(anywidget.AnyWidget):
         self.authorized_scopes = []
         self.status = "not_started"
         self.error_message = ""
+        
+        # Restore configuration properties
+        self.hostname = hostname
+        self.port = port
+        self.href = href
+        self.proxy = proxy
 
     def _make_request_with_fallback(self, url: str, method: str = "POST", data: Optional[Dict[str, Any]] = None, 
                                    headers: Optional[Dict[str, str]] = None, 

--- a/src/moutils/oauth.py
+++ b/src/moutils/oauth.py
@@ -1051,7 +1051,6 @@ class PKCEFlow(anywidget.AnyWidget):
 
     def _handle_callback(self, change: Dict[str, Any]) -> None:
         """Handle callback URL from the frontend."""
-        print(f"Callback URL received from frontend: {change['new']}")
         if change["new"]:
             self._log("Callback URL received from frontend")
             callback_url = change["new"]

--- a/uv.lock
+++ b/uv.lock
@@ -246,7 +246,7 @@ wheels = [
 
 [[package]]
 name = "moutils"
-version = "0.3.2"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
1) new tab for pages/wasm/deployed notebooks, opening a new tab and using a callback page to process the access token, persisting the state of the original notebook and listening for a change in that local storage
2) local python and local wasm (without pages) will now use "same tab" callbacks and accept the parameter from the URL. If there is a new token in the url, it will do this before checking local storage