### PR TITLE
chore(ci): split build.yml into build/publish/release-notes jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,13 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      id-token: write
-      contents: write
     env:
       UV_PYTHON: 3.12
 
@@ -27,22 +27,56 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Build package
-        run: |
-          uv build
+        run: uv build
+
+      - name: Upload package artifact
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: Download package artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        run: |
-          uv publish
+        run: uv publish
+
+  release-notes:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
 
       - name: ⎔ Setup Node.js
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
       - name: 📝 Update Changelog
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        run: npx changelogithub
+        run: npx changelogithub@14.0.0
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Scopes `id-token: write` to a publish-only job (uv publish from downloaded artifact). Build runs without OIDC scope, and `npx changelogithub@14.0.0` runs in a separate job with only `contents: write`.

Also pins changelogithub to a stable version (14.0.0, 2025-11-25) and uses `--ignore-scripts` indirectly by isolating npm execution from the publishing job.

Resolves the supply-chain audit `oidc-publish-fused` finding for this repo.