### PR TITLE
fix: concurrent_map using iter with total shows spinner instead of progress bar

### DIFF
--- a/src/moutils/concurrent.py
+++ b/src/moutils/concurrent.py
@@ -35,11 +35,11 @@ def concurrent_map[T, R](
     try:
         with pool(max_workers=max_workers) as executor:
             futures = executor.map(fn, iterable)
+            if total is None and isinstance(iterable, Sized):
+                total = len(iterable)
             if disabled:
                 results = list(futures)
-            elif isinstance(iterable, Sized):
-                if total is None:
-                    total = len(iterable)
+            elif total is not None:
                 results = list(
                     mo.status.progress_bar(
                         futures,

--- a/src/moutils/concurrent.py
+++ b/src/moutils/concurrent.py
@@ -14,11 +14,15 @@ import marimo as mo
 
 
 def concurrent_map[T, R](
-    # Note: The `Executor` abstract base class does not specify arguments in __init__(),
-    # so we specify a union of the individual types. Also, InterpreterPoolExecutor is
-    # only available in Python 3.14+, so we use a string literal to avoid import errors
-    # in older versions, but `|` unions cannot exist between a type and a string
-    # literal, so we have to union the two `Type`s separately.
+    # Note: The `Executor` base class does not specify arguments in __init__(), so we
+    # specify a union of the individual types. Ideally, there would be a Protocol for
+    # this, but making one is more trouble than it's worth and more likely to have a
+    # bug. tqdm solves this by not even giving a type hint for its `pool` equivalent.
+    #
+    # Also, because InterpreterPoolExecutor is only available in Python 3.14+, we use a
+    # string literal to avoid import errors in older versions. Since `|` unions cannot
+    # exist between a type and a string literal, so we have to union the two `Type`s
+    # separately.
     pool: Type[ThreadPoolExecutor | ProcessPoolExecutor]
     | Type["InterpreterPoolExecutor"],
     fn: Callable[[T], R],

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -75,7 +75,7 @@ class TestConcurrentMap:
 
         iterable = iterable_cls([1, 2, 3])
         result = concurrent_map(
-            DummyExecutor,
+            DummyExecutor,  # type: ignore  # Because there is no PoolExecutor protocol
             _double,
             iterable,
             total=total,
@@ -97,7 +97,7 @@ class TestConcurrentMap:
         status = mock_mo_status
 
         result = concurrent_map(
-            DummyExecutor,
+            DummyExecutor,  # type: ignore  # Because there is no PoolExecutor protocol
             fn=_double,
             iterable=[4, 5],
             total=None,

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -1,0 +1,109 @@
+"""Tests for concurrent execution helpers."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+import moutils.concurrent as concurrent_module
+from moutils.concurrent import concurrent_map
+
+
+class DummyExecutor:
+    def __init__(self, max_workers=None):
+        self.max_workers = max_workers
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def map(self, fn, iterable):
+        return (fn(item) for item in iterable)
+
+
+class MockStatus:
+    def __init__(self):
+        self.progress_bar_calls = []
+        self.spinner_calls = []
+
+    def progress_bar(self, iterable, **kwargs):
+        self.progress_bar_calls.append(kwargs)
+        return iterable
+
+    @contextmanager
+    def spinner(self, **kwargs):
+        self.spinner_calls.append(kwargs)
+        yield
+
+
+@pytest.fixture
+def mock_mo_status(monkeypatch: pytest.MonkeyPatch) -> MockStatus:
+    status = MockStatus()
+    fake_marimo = SimpleNamespace(
+        status=status,
+        stop=lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(concurrent_module, "mo", fake_marimo)
+    return status
+
+
+def _double(value):
+    return value * 2
+
+
+class TestConcurrentMap:
+    @pytest.mark.parametrize(
+        "iterable_cls,total,expected_branch,expected_total",
+        [
+            (list, None, "progress_bar", 3),
+            (iter, None, "spinner", None),
+            (list, 10, "progress_bar", 10),
+            (iter, 10, "progress_bar", 10),
+        ],
+    )
+    def test_progress_bar_or_spinner(
+        self,
+        mock_mo_status: MockStatus,
+        iterable_cls,
+        total,
+        expected_branch,
+        expected_total,
+    ):
+        status = mock_mo_status
+
+        iterable = iterable_cls([1, 2, 3])
+        result = concurrent_map(
+            DummyExecutor,
+            _double,
+            iterable,
+            total=total,
+        )
+
+        assert result == [2, 4, 6]
+
+        if expected_branch == "progress_bar":
+            assert len(status.progress_bar_calls) == 1
+            assert status.progress_bar_calls[0]["total"] == expected_total
+            assert status.spinner_calls == []
+        else:
+            assert status.progress_bar_calls == []
+            assert len(status.spinner_calls) == 1
+
+    def test_use_iterable_length_when_total_is_missing(
+        self, mock_mo_status: MockStatus
+    ):
+        status = mock_mo_status
+
+        result = concurrent_map(
+            DummyExecutor,
+            fn=_double,
+            iterable=[4, 5],
+            total=None,
+        )
+
+        assert result == [8, 10]
+        assert len(status.progress_bar_calls) == 1
+        assert status.progress_bar_calls[0]["total"] == 2
+        assert status.spinner_calls == []


### PR DESCRIPTION
- Fixed: Using `concurrent_map()` with an iterator (so, not `Sized`) and specifying a `total` showed a spinner instead of a progress bar. 
- Tests: Added tests for `concurrent_map()` shows the correct spinner or progress bar.