### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# moutils
+
+Utility [anywidget](https://anywidget.dev) components (URL/DOM/clipboard/camera/etc.) for marimo notebooks. Published to PyPI as `moutils`.
+
+## Development
+
+```bash
+uv sync                 # create env + install (src/ layout)
+uv run pytest           # run tests
+uvx ruff format . && uvx ruff check .   # format + lint
+uv build                # build sdist/wheel
+```
+
+- Python package lives under `src/moutils/`; widget JS/CSS in `src/moutils/static/`.
+- Linting/formatting also run via pre-commit (org-wide pre-commit.ci); `pre-commit run -a` mirrors CI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adopts the marimo-team convention where AGENTS.md is the canonical agent-context doc and CLAUDE.md is a symlink to it (`ln -s AGENTS.md CLAUDE.md`), so every agent reads one source of truth. The doc is deliberately minimal — a one-line overview plus verified development commands — because it loads into every agent context and fewer tokens is better. Part of the marimo-team engineering-excellence initiative to give agents consistent, low-overhead repo context.