### PR TITLE
feat(db): add moutils.db submodule with PostHog + Datasette connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,15 @@ Create the connection in a Python cell. Use a PostHog personal API key.
 ```python
 from moutils.db.posthog import PostHogConnection
 
-posthog = PostHogConnection(api_key="phx_...", project_id=123)
+posthog = PostHogConnection(
+    api_key="phx_...",
+    project_id=123,
+    page_size=10_000,
+)
 ```
 
-Then run HogQL in a SQL cell:
+`page_size` is required because PostHog otherwise returns at most 100 rows. Use a
+value from 1 through 50,000. Then run HogQL in a SQL cell:
 
 ```sql
 SELECT event, count() FROM events GROUP BY event

--- a/README.md
+++ b/README.md
@@ -281,6 +281,57 @@ import moutils
 moutils.screenshot(locator="#my-chart", filename="chart.png")
 ```
 
+## Database connections
+
+`moutils.db` provides read-only [DB-API 2.0](https://peps.python.org/pep-0249/)
+connections over REST query APIs. Assign one to a notebook variable and marimo
+detects it as a SQL engine, so you can query it directly from SQL cells.
+
+| Connection | Description |
+|------------|-------------|
+| `PostHogConnection` | Query a PostHog project via its HogQL API (`clickhouse` dialect) |
+| `DatasetteConnection` | Query one database of a [Datasette](https://datasette.io) instance (`sqlite` dialect) |
+
+`PostHogConnection` uses `requests` (already a base dependency).
+`DatasetteConnection` uses `httpx`, available via the optional extra:
+
+```sh
+pip install moutils[db]
+```
+
+### PostHogConnection
+
+Assign the connection in a Python cell:
+
+```python
+from moutils.db import PostHogConnection
+
+posthog = PostHogConnection(api_key="phx_...", project_id=123)
+```
+
+marimo now picks it up as a SQL engine, so you can query it from a SQL cell:
+
+```sql
+SELECT event, count() FROM events GROUP BY event
+```
+
+### DatasetteConnection
+
+```python
+from moutils.db import DatasetteConnection
+
+datasette = DatasetteConnection("https://datasette.io", "content", token="...")
+```
+
+Then query it from a SQL cell:
+
+```sql
+SELECT * FROM tables LIMIT 10
+```
+
+A connection is scoped to one database; `datasette.databases()` lists the others
+on the instance and `datasette.for_database("everest")` opens a sibling.
+
 ## Development
 
 We use [uv](https://github.com/astral-sh/uv) for development.

--- a/README.md
+++ b/README.md
@@ -283,26 +283,25 @@ moutils.screenshot(locator="#my-chart", filename="chart.png")
 
 ## Database connections
 
-`moutils.db` provides read-only [DB-API 2.0](https://peps.python.org/pep-0249/)
-connections over REST query APIs. Import one from its submodule, assign it to a
-notebook variable, and marimo detects it as a SQL engine — so you can query it
-directly from SQL cells.
+`moutils.db` provides read-only REST connections for marimo SQL cells. Import a
+connection and assign it to a notebook variable. marimo detects the variable as
+a SQL engine.
 
 | Connection | Description |
 |------------|-------------|
 | `PostHogConnection` | Query a PostHog project via its HogQL API (`clickhouse` dialect) |
 | `DatasetteConnection` | Query one database of a [Datasette](https://datasette.io) instance (`sqlite` dialect) |
 
-`PostHogConnection` uses `requests` (already a base dependency).
-`DatasetteConnection` uses `httpx`, available via the optional extra:
+`PostHogConnection` uses the base `requests` dependency. Install the optional
+`db` dependency for `DatasetteConnection`:
 
 ```sh
-pip install moutils[db]
+pip install "moutils[db]"
 ```
 
 ### PostHogConnection
 
-Assign the connection in a Python cell:
+Create the connection in a Python cell. Use a PostHog personal API key.
 
 ```python
 from moutils.db.posthog import PostHogConnection
@@ -310,7 +309,7 @@ from moutils.db.posthog import PostHogConnection
 posthog = PostHogConnection(api_key="phx_...", project_id=123)
 ```
 
-marimo now picks it up as a SQL engine, so you can query it from a SQL cell:
+Then run HogQL in a SQL cell:
 
 ```sql
 SELECT event, count() FROM events GROUP BY event
@@ -324,14 +323,17 @@ from moutils.db.datasette import DatasetteConnection
 datasette = DatasetteConnection("https://datasette.io", "content", token="...")
 ```
 
-Then query it from a SQL cell:
+Then run SQLite SQL in a SQL cell:
 
 ```sql
 SELECT * FROM tables LIMIT 10
 ```
 
-A connection is scoped to one database; `datasette.databases()` lists the others
-on the instance and `datasette.for_database("everest")` opens a sibling.
+A connection uses one database. Use `datasette.databases()` to list the database
+routes. Use `datasette.for_database("everest")` to connect to another database.
+
+These connections do not support bound parameters. Use static or trusted SQL.
+Do not insert untrusted values into SQL strings.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -284,8 +284,9 @@ moutils.screenshot(locator="#my-chart", filename="chart.png")
 ## Database connections
 
 `moutils.db` provides read-only [DB-API 2.0](https://peps.python.org/pep-0249/)
-connections over REST query APIs. Assign one to a notebook variable and marimo
-detects it as a SQL engine, so you can query it directly from SQL cells.
+connections over REST query APIs. Import one from its submodule, assign it to a
+notebook variable, and marimo detects it as a SQL engine — so you can query it
+directly from SQL cells.
 
 | Connection | Description |
 |------------|-------------|
@@ -304,7 +305,7 @@ pip install moutils[db]
 Assign the connection in a Python cell:
 
 ```python
-from moutils.db import PostHogConnection
+from moutils.db.posthog import PostHogConnection
 
 posthog = PostHogConnection(api_key="phx_...", project_id=123)
 ```
@@ -318,7 +319,7 @@ SELECT event, count() FROM events GROUP BY event
 ### DatasetteConnection
 
 ```python
-from moutils.db import DatasetteConnection
+from moutils.db.datasette import DatasetteConnection
 
 datasette = DatasetteConnection("https://datasette.io", "content", token="...")
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,4 +46,3 @@ pythonpath = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
-addopts = "--import-mode=importlib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,23 @@ version = "0.4.4"
 # If you're using `uv` for development, feel free to remove this section.
 [project.optional-dependencies]
 dev = ["marimo"]
+# Database connections (moutils.db). PostHog uses `requests` (a base dep);
+# Datasette needs httpx. Install with `pip install moutils[db]`.
+db = ["httpx>=0.27"]
 
 # Dependency groups (recognized by `uv`). For more details, visit:
 # https://peps.python.org/pep-0735/
 [dependency-groups]
-dev = ["marimo", "pytest"]
+dev = [
+  "marimo",
+  "pytest",
+  # moutils.db test stack
+  "httpx>=0.27",
+  "responses>=0.25",
+  "pytest-httpx>=0.30",
+  "datasette>=0.64,<1",
+  "datasette-auth-tokens>=0.3,<0.4",
+]
 
 [tool.ruff.lint.per-file-ignores]
 # This snippet is injected verbatim into an `async def _():` marimo/Pyodide
@@ -34,3 +46,4 @@ pythonpath = ["src"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+addopts = "--import-mode=importlib"

--- a/src/moutils/db/__init__.py
+++ b/src/moutils/db/__init__.py
@@ -1,7 +1,6 @@
-"""Read-only DB-API 2.0 connections over REST query APIs, for marimo SQL cells.
+"""Read-only REST connections for marimo SQL cells.
 
-Import a connection from its submodule and assign it to a notebook variable;
-marimo then detects it as a SQL engine and you can query it from SQL cells:
+Import a connection from its submodule. Then assign it to a notebook variable:
 
     from moutils.db.posthog import PostHogConnection
     from moutils.db.datasette import DatasetteConnection
@@ -9,6 +8,5 @@ marimo then detects it as a SQL engine and you can query it from SQL cells:
     posthog = PostHogConnection(api_key="phx_...", project_id=123)
     datasette = DatasetteConnection("https://example.com", "mydb")
 
-PostHog uses ``requests`` (a base moutils dependency); Datasette uses ``httpx``,
-available via the optional extra: ``pip install moutils[db]``.
+PostHog uses ``requests``. Datasette requires the ``db`` optional dependency.
 """

--- a/src/moutils/db/__init__.py
+++ b/src/moutils/db/__init__.py
@@ -1,8 +1,10 @@
 """Read-only DB-API 2.0 connections over REST query APIs, for marimo SQL cells.
 
-Assign a connection to a notebook variable and marimo detects it as a SQL engine:
+Import a connection from its submodule and assign it to a notebook variable;
+marimo then detects it as a SQL engine and you can query it from SQL cells:
 
-    from moutils.db import PostHogConnection, DatasetteConnection
+    from moutils.db.posthog import PostHogConnection
+    from moutils.db.datasette import DatasetteConnection
 
     posthog = PostHogConnection(api_key="phx_...", project_id=123)
     datasette = DatasetteConnection("https://example.com", "mydb")
@@ -10,15 +12,3 @@ Assign a connection to a notebook variable and marimo detects it as a SQL engine
 PostHog uses ``requests`` (a base moutils dependency); Datasette uses ``httpx``,
 available via the optional extra: ``pip install moutils[db]``.
 """
-
-from ._core import Connection, Cursor
-from .datasette import DatasetteConnection, databases
-from .posthog import PostHogConnection
-
-__all__ = [
-    "PostHogConnection",
-    "DatasetteConnection",
-    "databases",
-    "Connection",
-    "Cursor",
-]

--- a/src/moutils/db/__init__.py
+++ b/src/moutils/db/__init__.py
@@ -1,0 +1,24 @@
+"""Read-only DB-API 2.0 connections over REST query APIs, for marimo SQL cells.
+
+Assign a connection to a notebook variable and marimo detects it as a SQL engine:
+
+    from moutils.db import PostHogConnection, DatasetteConnection
+
+    posthog = PostHogConnection(api_key="phx_...", project_id=123)
+    datasette = DatasetteConnection("https://example.com", "mydb")
+
+PostHog uses ``requests`` (a base moutils dependency); Datasette uses ``httpx``,
+available via the optional extra: ``pip install moutils[db]``.
+"""
+
+from ._core import Connection, Cursor
+from .datasette import DatasetteConnection, databases
+from .posthog import PostHogConnection
+
+__all__ = [
+    "PostHogConnection",
+    "DatasetteConnection",
+    "databases",
+    "Connection",
+    "Cursor",
+]

--- a/src/moutils/db/__init__.py
+++ b/src/moutils/db/__init__.py
@@ -5,7 +5,9 @@ Import a connection from its submodule. Then assign it to a notebook variable:
     from moutils.db.posthog import PostHogConnection
     from moutils.db.datasette import DatasetteConnection
 
-    posthog = PostHogConnection(api_key="phx_...", project_id=123)
+    posthog = PostHogConnection(
+        api_key="phx_...", project_id=123, page_size=10_000
+    )
     datasette = DatasetteConnection("https://example.com", "mydb")
 
 PostHog uses ``requests``. Datasette requires the ``db`` optional dependency.

--- a/src/moutils/db/_core.py
+++ b/src/moutils/db/_core.py
@@ -1,27 +1,20 @@
-"""Shared DB-API 2.0 machinery for the moutils database connectors.
-
-marimo detects any object exposing the DB-API surface (``cursor``/``commit``/
-``rollback``/``close`` + an executable cursor) as a SQL engine, so assigning an
-instance to a notebook variable makes the source available in SQL cells. The
-class attr ``dialect`` tells marimo which SQL flavour to parse.
-
-The cursor knows nothing about any particular data source: ``execute`` delegates
-to the owning connection's ``_fetch(query) -> (columns, rows, types)`` and builds
-the DB-API ``description`` from that triple. All paging/fetch state lives here, so
-a connector only has to implement transport + result-mapping.
-
-Subclasses must set ``dialect`` and implement:
-
-    _fetch(query) -> (columns, rows, types | None)   # used by the cursor
-    schema_rows() -> list[{"table", "column", "type"}]  # schema discovery
-"""
+"""Shared DB-API-compatible classes for the REST connections."""
 
 from abc import ABC, abstractmethod
 from typing import Any, Sequence
 
 
+def _type_code(types: list[Any], index: int) -> Any:
+    if index >= len(types):
+        return None
+    type_ = types[index]
+    if isinstance(type_, (list, tuple)) and len(type_) > 1:
+        return type_[1]
+    return type_
+
+
 class Cursor:
-    """Minimal DB-API 2.0 cursor backed by a connection's ``_fetch``."""
+    """A minimal DB-API-compatible cursor."""
 
     def __init__(self, connection: Any) -> None:
         self._connection = connection
@@ -33,18 +26,14 @@ class Cursor:
         self._pos = 0
 
     def execute(self, query: str, parameters: Sequence[Any] | None = None) -> "Cursor":
-        # Parameter binding isn't implemented; reject it loudly rather than
-        # silently ignoring `parameters`.
+        # marimo passes an empty tuple when a query has no parameters.
         if parameters:
             raise NotImplementedError(
-                "moutils.db cursors do not support parameter binding; "
-                "interpolate values into the SQL query string yourself."
+                "moutils.db cursors do not support bound parameters. "
+                "Pass a query without parameters."
             )
         columns, rows, types = self._connection._fetch(query)
-        # `types`, when present, is a list of [name, type] pairs (HogQL) or bare
-        # type strings; connectors with no per-column types return None.
-        if not types:
-            types = [None] * len(columns)
+        types = list(types or ())
         self._rows = [list(row) for row in rows]
         self._pos = 0
         self.rowcount = len(self._rows)
@@ -53,14 +42,14 @@ class Cursor:
         self.description = [
             (
                 str(name),
-                (t[1] if isinstance(t, (list, tuple)) and len(t) > 1 else t),
+                _type_code(types, index),
                 None,
                 None,
                 None,
                 None,
                 None,
             )
-            for name, t in zip(columns, types)
+            for index, name in enumerate(columns)
         ]
         return self
 
@@ -88,12 +77,7 @@ class Cursor:
 
 
 class Connection(ABC):
-    """DB-API 2.0 connection base for read-only REST-backed data sources.
-
-    Abstract: a subclass must set ``dialect`` and implement the ``_fetch`` and
-    ``schema_rows`` hooks below, so an incomplete connector fails at instantiation
-    rather than at query time.
-    """
+    """Base class for read-only REST connections."""
 
     dialect: str = ""
 
@@ -109,7 +93,6 @@ class Connection(ABC):
     def close(self) -> None:
         pass
 
-    # --- hooks a connector must provide -------------------------------------
     @abstractmethod
     def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
         """Return ``(columns, rows, types | None)`` for the shared cursor."""

--- a/src/moutils/db/_core.py
+++ b/src/moutils/db/_core.py
@@ -16,6 +16,7 @@ Subclasses must set ``dialect`` and implement:
     schema_rows() -> list[{"table", "column", "type"}]  # schema discovery
 """
 
+from abc import ABC, abstractmethod
 from typing import Any, Sequence
 
 
@@ -86,8 +87,13 @@ class Cursor:
         self._pos = 0
 
 
-class Connection:
-    """DB-API 2.0 connection base for read-only REST-backed data sources."""
+class Connection(ABC):
+    """DB-API 2.0 connection base for read-only REST-backed data sources.
+
+    Abstract: a subclass must set ``dialect`` and implement the ``_fetch`` and
+    ``schema_rows`` hooks below, so an incomplete connector fails at instantiation
+    rather than at query time.
+    """
 
     dialect: str = ""
 
@@ -104,8 +110,10 @@ class Connection:
         pass
 
     # --- hooks a connector must provide -------------------------------------
+    @abstractmethod
     def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
-        raise NotImplementedError
+        """Return ``(columns, rows, types | None)`` for the shared cursor."""
 
+    @abstractmethod
     def schema_rows(self) -> list[dict[str, Any]]:
-        raise NotImplementedError
+        """Return ``{"table", "column", "type"}`` rows describing the schema."""

--- a/src/moutils/db/_core.py
+++ b/src/moutils/db/_core.py
@@ -1,0 +1,111 @@
+"""Shared DB-API 2.0 machinery for the moutils database connectors.
+
+marimo detects any object exposing the DB-API surface (``cursor``/``commit``/
+``rollback``/``close`` + an executable cursor) as a SQL engine, so assigning an
+instance to a notebook variable makes the source available in SQL cells. The
+class attr ``dialect`` tells marimo which SQL flavour to parse.
+
+The cursor knows nothing about any particular data source: ``execute`` delegates
+to the owning connection's ``_fetch(query) -> (columns, rows, types)`` and builds
+the DB-API ``description`` from that triple. All paging/fetch state lives here, so
+a connector only has to implement transport + result-mapping.
+
+Subclasses must set ``dialect`` and implement:
+
+    _fetch(query) -> (columns, rows, types | None)   # used by the cursor
+    schema_rows() -> list[{"table", "column", "type"}]  # schema discovery
+"""
+
+from typing import Any, Sequence
+
+
+class Cursor:
+    """Minimal DB-API 2.0 cursor backed by a connection's ``_fetch``."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+        self.arraysize = 1
+        self.description: Any = None
+        self.rowcount: int = -1
+        self.lastrowid = None
+        self._rows: list[list[Any]] = []
+        self._pos = 0
+
+    def execute(self, query: str, parameters: Sequence[Any] | None = None) -> "Cursor":
+        # Parameter binding isn't implemented; reject it loudly rather than
+        # silently ignoring `parameters`.
+        if parameters:
+            raise NotImplementedError(
+                "moutils.db cursors do not support parameter binding; "
+                "interpolate values into the SQL query string yourself."
+            )
+        columns, rows, types = self._connection._fetch(query)
+        # `types`, when present, is a list of [name, type] pairs (HogQL) or bare
+        # type strings; connectors with no per-column types return None.
+        if not types:
+            types = [None] * len(columns)
+        self._rows = [list(row) for row in rows]
+        self._pos = 0
+        self.rowcount = len(self._rows)
+        # DB-API description: (name, type_code, display_size, internal_size,
+        # precision, scale, null_ok)
+        self.description = [
+            (
+                str(name),
+                (t[1] if isinstance(t, (list, tuple)) and len(t) > 1 else t),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            for name, t in zip(columns, types)
+        ]
+        return self
+
+    def fetchall(self) -> list[list[Any]]:
+        rest = self._rows[self._pos :]
+        self._pos = len(self._rows)
+        return rest
+
+    def fetchone(self) -> list[Any] | None:
+        if self._pos >= len(self._rows):
+            return None
+        row = self._rows[self._pos]
+        self._pos += 1
+        return row
+
+    def fetchmany(self, size: int | None = None) -> list[list[Any]]:
+        size = self.arraysize if size is None else size
+        chunk = self._rows[self._pos : self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+    def close(self) -> None:
+        self._rows = []
+        self._pos = 0
+
+
+class Connection:
+    """DB-API 2.0 connection base for read-only REST-backed data sources."""
+
+    dialect: str = ""
+
+    def cursor(self) -> Cursor:
+        return Cursor(self)
+
+    def commit(self) -> None:  # no-op: moutils.db connectors are read-only
+        pass
+
+    def rollback(self) -> None:  # no-op: moutils.db connectors are read-only
+        pass
+
+    def close(self) -> None:
+        pass
+
+    # --- hooks a connector must provide -------------------------------------
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        raise NotImplementedError
+
+    def schema_rows(self) -> list[dict[str, Any]]:
+        raise NotImplementedError

--- a/src/moutils/db/datasette.py
+++ b/src/moutils/db/datasette.py
@@ -1,23 +1,10 @@
-"""DB-API 2.0 connection over a Datasette instance's JSON query API.
-
-Built on :mod:`moutils.db._core`: paging/``description`` live in the shared
-``Cursor``, so this module only owns the ``httpx`` transport, the result mapping
-(``_fetch``), and schema discovery.
-
-Datasette serves SQLite over an HTTP JSON API. Arbitrary SQL goes to
-``GET {base_url}/{database}.json?sql=...&_shape=arrays``, which returns a
-``{"columns": [...], "rows": [[...]], "truncated": bool, "ok": bool}`` envelope;
-SQL errors come back as HTTP 4xx with ``{"ok": false, "error": "..."}``.
-
-``httpx`` is an optional dependency (install with ``pip install moutils[db]``); it
-is imported lazily so importing this module never requires it — only constructing
-a :class:`DatasetteConnection` (or calling :func:`databases`) does.
-"""
+"""Read-only marimo SQL connection for Datasette."""
 
 from __future__ import annotations
 
 import warnings
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     import httpx
@@ -46,32 +33,10 @@ def _require_httpx() -> Any:
 
 
 class DatasetteConnection(Connection):
-    """DB-API 2.0 connection over **one** database of a Datasette instance.
+    """Connect to one database in a Datasette instance.
 
-    A connection is scoped to a single database because that's how Datasette
-    scopes SQL: queries go to ``{base_url}/{database}.json?sql=...``, and one
-    database can't reach another's tables. ``dialect="sqlite"`` makes marimo
-    parse cells as SQLite and detect the connection as a SQL engine.
-
-    Discovering the other databases on the same instance
-    ----------------------------------------------------
-    A Datasette instance usually serves several databases. From a single
-    connection you can list its siblings and open one of them::
-
-        conn = DatasetteConnection("https://example.com", "earthquakes")
-        conn.databases()                       # -> ['earthquakes', 'everest', ...]
-        everest = conn.for_database("everest") # a new connection to another db
-
-    ``databases()`` uses Datasette's ``/-/databases.json`` introspection endpoint
-    (carrying this connection's token). To browse the tables/columns *within*
-    this database, use :meth:`schema_rows`.
-
-    Notes
-    -----
-    * Datasette caps arbitrary-SQL results at ``max_returned_rows`` (default
-      1000); when a result is truncated the connection emits a ``UserWarning``.
-      Add a ``LIMIT`` (or raise Datasette's ``max_returned_rows``) to control it.
-    * Pass ``token=`` for an instance behind bearer-token auth.
+    Set ``token`` for bearer-token authentication. Datasette can limit query
+    results. This connection warns when the server truncates a result.
     """
 
     dialect = "sqlite"
@@ -94,21 +59,27 @@ class DatasetteConnection(Connection):
 
     def _run_sql(self, sql: str) -> dict:
         headers = {"Authorization": f"Bearer {self._token}"} if self._token else {}
+        database = quote(self._database, safe="")
+        # Datasette 0.x uses this URL. Datasette 1.x redirects it to
+        # /<database>/-/query.json, so follow that redirect for compatibility.
         resp = self._client.get(
-            f"{self._base_url}/{self._database}.json",
-            params={"sql": sql, "_shape": "arrays"},
+            f"{self._base_url}/{database}.json",
+            params={"sql": sql, "_shape": "arrays", "_extra": "columns"},
             headers=headers,
+            follow_redirects=True,
         )
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ValueError("unexpected Datasette response: expected an object")
+        if data.get("ok") is False:
+            raise ValueError(
+                f"Datasette query failed: {data.get('error', 'unknown error')}"
+            )
+        return data
 
     def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
-        """Return ``(columns, rows, types)`` for the shared cursor.
-
-        SQLite query results carry no per-column types (dynamic typing), so
-        ``types`` is None — DB-API type codes come out as None; column types are
-        available via :meth:`schema_rows` instead.
-        """
+        """Return columns and rows for the shared cursor."""
         data = self._run_sql(query)
         if data.get("truncated"):
             warnings.warn(
@@ -117,14 +88,14 @@ class DatasetteConnection(Connection):
                 "max_returned_rows) to fetch the rest.",
                 stacklevel=3,
             )
-        return data.get("columns") or [], data.get("rows", []), None
+        columns = data.get("columns")
+        rows = data.get("rows")
+        if not isinstance(columns, list) or not isinstance(rows, list):
+            raise ValueError("unexpected Datasette query response shape")
+        return columns, rows, None
 
     def schema_rows(self) -> list[dict[str, Any]]:
-        """Return ``{"table", "column", "type"}`` rows for every user table.
-
-        Raises ``ValueError`` if the response isn't the expected 3-column shape —
-        fail early rather than hand back a malformed schema.
-        """
+        """Return the columns and types for each user table."""
         data = self._run_sql(_SCHEMA_SQL)
         columns = data.get("columns")
         rows = data.get("rows")
@@ -140,21 +111,11 @@ class DatasetteConnection(Connection):
         ]
 
     def databases(self) -> list[str]:
-        """List the databases served by this connection's Datasette instance.
-
-        Discovery from a single connection: hits ``/-/databases.json`` with this
-        connection's base URL, token, and pooled client, skipping the in-memory
-        cross-database database. Pair with :meth:`for_database` to open one.
-        See also the module-level :func:`databases`.
-        """
+        """Return the databases on this Datasette instance."""
         return databases(self._base_url, self._token, client=self._client)
 
     def for_database(self, database: str) -> "DatasetteConnection":
-        """Open a new connection to another database on the same instance.
-
-        Reuses this connection's base URL and token. Datasette scopes SQL per
-        database, so a sibling database is a separate connection.
-        """
+        """Connect to another database on the same instance."""
         return DatasetteConnection(self._base_url, database, token=self._token)
 
     def close(self) -> None:
@@ -168,21 +129,23 @@ def databases(
     *,
     client: httpx.Client | None = None,
 ) -> list[str]:
-    """Return the database names a Datasette instance serves.
-
-    Uses Datasette's documented ``/-/databases.json`` introspection endpoint
-    (gated by the same permission as querying, so ``token`` flows through). The
-    in-memory cross-database database (``_memory``) is skipped — it isn't a real
-    dataset. Returns each database's ``route`` (the URL-safe name used in the
-    query endpoint).
-    """
+    """Return the database routes on a Datasette instance."""
     owns = client is None
     client = client or _require_httpx().Client(timeout=120)
     try:
         headers = {"Authorization": f"Bearer {token}"} if token else {}
         resp = client.get(f"{base_url.rstrip('/')}/-/databases.json", headers=headers)
         resp.raise_for_status()
-        return [d["route"] for d in resp.json() if not d.get("is_memory")]
+        data = resp.json()
+        entries = data.get("databases") if isinstance(data, dict) else data
+        if not isinstance(entries, list) or not all(
+            isinstance(entry, dict) for entry in entries
+        ):
+            raise ValueError("unexpected Datasette databases response shape")
+        routes = [entry.get("route") for entry in entries if not entry.get("is_memory")]
+        if not all(isinstance(route, str) for route in routes):
+            raise ValueError("unexpected Datasette database route")
+        return routes
     finally:
         if owns:
             client.close()

--- a/src/moutils/db/datasette.py
+++ b/src/moutils/db/datasette.py
@@ -115,8 +115,13 @@ class DatasetteConnection(Connection):
         return databases(self._base_url, self._token, client=self._client)
 
     def for_database(self, database: str) -> "DatasetteConnection":
-        """Connect to another database on the same instance."""
-        return DatasetteConnection(self._base_url, database, token=self._token)
+        """Connect to another database with the same HTTP client."""
+        return DatasetteConnection(
+            self._base_url,
+            database,
+            token=self._token,
+            client=self._client,
+        )
 
     def close(self) -> None:
         if self._owns_client:

--- a/src/moutils/db/datasette.py
+++ b/src/moutils/db/datasette.py
@@ -1,0 +1,188 @@
+"""DB-API 2.0 connection over a Datasette instance's JSON query API.
+
+Built on :mod:`moutils.db._core`: paging/``description`` live in the shared
+``Cursor``, so this module only owns the ``httpx`` transport, the result mapping
+(``_fetch``), and schema discovery.
+
+Datasette serves SQLite over an HTTP JSON API. Arbitrary SQL goes to
+``GET {base_url}/{database}.json?sql=...&_shape=arrays``, which returns a
+``{"columns": [...], "rows": [[...]], "truncated": bool, "ok": bool}`` envelope;
+SQL errors come back as HTTP 4xx with ``{"ok": false, "error": "..."}``.
+
+``httpx`` is an optional dependency (install with ``pip install moutils[db]``); it
+is imported lazily so importing this module never requires it — only constructing
+a :class:`DatasetteConnection` (or calling :func:`databases`) does.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
+
+from ._core import Connection
+
+# One round-trip that yields (table, column, type) for every user table, using
+# SQLite's table-valued pragma function joined against sqlite_master.
+_SCHEMA_SQL = (
+    'select m.name as "table", p.name as "column", p.type as "type" '
+    "from sqlite_master m join pragma_table_info(m.name) p "
+    "where m.type = 'table' and m.name not like 'sqlite_%' "
+    "order by m.name, p.cid"
+)
+
+
+def _require_httpx() -> Any:
+    try:
+        import httpx
+    except ImportError as exc:  # pragma: no cover - exercised only without httpx
+        raise ImportError(
+            "DatasetteConnection requires httpx. "
+            "Install it with `pip install moutils[db]`."
+        ) from exc
+    return httpx
+
+
+class DatasetteConnection(Connection):
+    """DB-API 2.0 connection over **one** database of a Datasette instance.
+
+    A connection is scoped to a single database because that's how Datasette
+    scopes SQL: queries go to ``{base_url}/{database}.json?sql=...``, and one
+    database can't reach another's tables. ``dialect="sqlite"`` makes marimo
+    parse cells as SQLite and detect the connection as a SQL engine.
+
+    Discovering the other databases on the same instance
+    ----------------------------------------------------
+    A Datasette instance usually serves several databases. From a single
+    connection you can list its siblings and open one of them::
+
+        conn = DatasetteConnection("https://example.com", "earthquakes")
+        conn.databases()                       # -> ['earthquakes', 'everest', ...]
+        everest = conn.for_database("everest") # a new connection to another db
+
+    ``databases()`` uses Datasette's ``/-/databases.json`` introspection endpoint
+    (carrying this connection's token). To browse the tables/columns *within*
+    this database, use :meth:`schema_rows`.
+
+    Notes
+    -----
+    * Datasette caps arbitrary-SQL results at ``max_returned_rows`` (default
+      1000); when a result is truncated the connection emits a ``UserWarning``.
+      Add a ``LIMIT`` (or raise Datasette's ``max_returned_rows``) to control it.
+    * Pass ``token=`` for an instance behind bearer-token auth.
+    """
+
+    dialect = "sqlite"
+
+    def __init__(
+        self,
+        base_url: str,
+        database: str,
+        token: str | None = None,
+        *,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._database = database
+        self._token = token
+        self.database_name = database  # marimo catalog uses this as the DB label
+        # Reuse one client for connection pooling; only close what we created.
+        self._owns_client = client is None
+        self._client = client or _require_httpx().Client(timeout=120)
+
+    def _run_sql(self, sql: str) -> dict:
+        headers = {"Authorization": f"Bearer {self._token}"} if self._token else {}
+        resp = self._client.get(
+            f"{self._base_url}/{self._database}.json",
+            params={"sql": sql, "_shape": "arrays"},
+            headers=headers,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        """Return ``(columns, rows, types)`` for the shared cursor.
+
+        SQLite query results carry no per-column types (dynamic typing), so
+        ``types`` is None — DB-API type codes come out as None; column types are
+        available via :meth:`schema_rows` instead.
+        """
+        data = self._run_sql(query)
+        if data.get("truncated"):
+            warnings.warn(
+                "Datasette truncated the result set at max_returned_rows. "
+                "Add a LIMIT to your query (or raise Datasette's "
+                "max_returned_rows) to fetch the rest.",
+                stacklevel=3,
+            )
+        return data.get("columns") or [], data.get("rows", []), None
+
+    def schema_rows(self) -> list[dict[str, Any]]:
+        """Return ``{"table", "column", "type"}`` rows for every user table.
+
+        Raises ``ValueError`` if the response isn't the expected 3-column shape —
+        fail early rather than hand back a malformed schema.
+        """
+        data = self._run_sql(_SCHEMA_SQL)
+        columns = data.get("columns")
+        rows = data.get("rows")
+        if columns != ["table", "column", "type"] or rows is None:
+            raise ValueError(f"unexpected schema response shape: columns={columns!r}")
+        return [
+            {
+                "table": str(table),
+                "column": str(column),
+                "type": None if type_ is None else str(type_),
+            }
+            for table, column, type_ in rows
+        ]
+
+    def databases(self) -> list[str]:
+        """List the databases served by this connection's Datasette instance.
+
+        Discovery from a single connection: hits ``/-/databases.json`` with this
+        connection's base URL, token, and pooled client, skipping the in-memory
+        cross-database database. Pair with :meth:`for_database` to open one.
+        See also the module-level :func:`databases`.
+        """
+        return databases(self._base_url, self._token, client=self._client)
+
+    def for_database(self, database: str) -> "DatasetteConnection":
+        """Open a new connection to another database on the same instance.
+
+        Reuses this connection's base URL and token. Datasette scopes SQL per
+        database, so a sibling database is a separate connection.
+        """
+        return DatasetteConnection(self._base_url, database, token=self._token)
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+
+def databases(
+    base_url: str,
+    token: str | None = None,
+    *,
+    client: httpx.Client | None = None,
+) -> list[str]:
+    """Return the database names a Datasette instance serves.
+
+    Uses Datasette's documented ``/-/databases.json`` introspection endpoint
+    (gated by the same permission as querying, so ``token`` flows through). The
+    in-memory cross-database database (``_memory``) is skipped — it isn't a real
+    dataset. Returns each database's ``route`` (the URL-safe name used in the
+    query endpoint).
+    """
+    owns = client is None
+    client = client or _require_httpx().Client(timeout=120)
+    try:
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        resp = client.get(f"{base_url.rstrip('/')}/-/databases.json", headers=headers)
+        resp.raise_for_status()
+        return [d["route"] for d in resp.json() if not d.get("is_memory")]
+    finally:
+        if owns:
+            client.close()

--- a/src/moutils/db/posthog.py
+++ b/src/moutils/db/posthog.py
@@ -1,14 +1,4 @@
-"""DB-API 2.0 connection over PostHog's HogQL query API.
-
-Built on :mod:`moutils.db._core`: paging/``description`` live in the shared
-``Cursor``, so this module only owns the HTTP transport, the HogQL result mapping
-(``_fetch``), and schema discovery.
-
-Schema discovery goes through ``DatabaseSchemaQuery`` — the same authed POST the
-PostHog UI uses to build its schema tree. It does **not** swallow failures: an
-HTTP error propagates, and an unexpected response shape raises ``ValueError``.
-Fail early rather than hand back a stale, made-up table list.
-"""
+"""Read-only marimo SQL connection for PostHog HogQL."""
 
 from typing import Any
 
@@ -18,11 +8,7 @@ from ._core import Connection
 
 
 class PostHogConnection(Connection):
-    """DB-API 2.0 connection over the PostHog HogQL API.
-
-    ``dialect`` tells marimo to parse queries as ClickHouse, which HogQL is
-    closely modelled on, and makes marimo detect the connection as a SQL engine.
-    """
+    """Connect to a PostHog project with a personal API key."""
 
     dialect = "clickhouse"
 
@@ -47,19 +33,25 @@ class PostHogConnection(Connection):
             timeout=120,
         )
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ValueError("unexpected PostHog response: expected an object")
+        return data
 
     def _run_hogql(self, query: str) -> dict:
         return self._run_query({"kind": "HogQLQuery", "query": query})
 
     def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
-        """Return ``(columns, rows, types)`` for the shared cursor.
-
-        `types` is HogQL's list of ``[name, clickhouse_type]`` pairs when present
-        (or None); the cursor turns it into DB-API type codes.
-        """
+        """Return columns, rows, and types for the shared cursor."""
         data = self._run_hogql(query)
-        return data.get("columns") or [], data.get("results", []), data.get("types")
+        columns = data.get("columns")
+        rows = data.get("results")
+        types = data.get("types")
+        if not isinstance(columns, list) or not isinstance(rows, list):
+            raise ValueError("unexpected PostHog query response shape")
+        if types is not None and not isinstance(types, list):
+            raise ValueError("unexpected PostHog query types")
+        return columns, rows, types
 
     def schema_rows(self) -> list[dict[str, Any]]:
         """Return HogQL table/column/type rows (via ``DatabaseSchemaQuery``)."""
@@ -67,10 +59,7 @@ class PostHogConnection(Connection):
 
 
 def _rows_from_schema_response(data: dict) -> list[dict[str, Any]]:
-    """Flatten a DatabaseSchemaQuery reply into table/column/type rows.
-
-    Raises ``ValueError`` on any shape we don't recognise.
-    """
+    """Convert a schema response to table, column, and type rows."""
     tables = data.get("tables")
     if not isinstance(tables, dict) or not tables:
         raise ValueError("DatabaseSchemaQuery response has no 'tables' mapping")
@@ -103,10 +92,6 @@ def _rows_from_schema_response(data: dict) -> list[dict[str, Any]]:
 
 
 def schema_rows(conn: Any) -> list[dict[str, Any]]:
-    """Return table/column/type rows for the connection.
-
-    Propagates HTTP errors and raises ``ValueError`` on an unexpected response
-    shape — no fallback, no silent degradation.
-    """
+    """Return the table, column, and type rows for a connection."""
     data = conn._run_query({"kind": "DatabaseSchemaQuery"})
     return _rows_from_schema_response(data)

--- a/src/moutils/db/posthog.py
+++ b/src/moutils/db/posthog.py
@@ -1,0 +1,112 @@
+"""DB-API 2.0 connection over PostHog's HogQL query API.
+
+Built on :mod:`moutils.db._core`: paging/``description`` live in the shared
+``Cursor``, so this module only owns the HTTP transport, the HogQL result mapping
+(``_fetch``), and schema discovery.
+
+Schema discovery goes through ``DatabaseSchemaQuery`` — the same authed POST the
+PostHog UI uses to build its schema tree. It does **not** swallow failures: an
+HTTP error propagates, and an unexpected response shape raises ``ValueError``.
+Fail early rather than hand back a stale, made-up table list.
+"""
+
+from typing import Any
+
+import requests
+
+from ._core import Connection
+
+
+class PostHogConnection(Connection):
+    """DB-API 2.0 connection over the PostHog HogQL API.
+
+    ``dialect`` tells marimo to parse queries as ClickHouse, which HogQL is
+    closely modelled on, and makes marimo detect the connection as a SQL engine.
+    """
+
+    dialect = "clickhouse"
+
+    def __init__(
+        self,
+        api_key: str,
+        project_id: str | int,
+        host: str = "https://us.posthog.com",
+    ) -> None:
+        self._api_key = api_key
+        self._project_id = str(project_id)  # accept int, normalise for the URL
+        self._host = host.rstrip("/")
+
+    def _run_query(self, query: dict) -> dict:
+        resp = requests.post(
+            f"{self._host}/api/projects/{self._project_id}/query/",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json={"query": query},
+            timeout=120,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _run_hogql(self, query: str) -> dict:
+        return self._run_query({"kind": "HogQLQuery", "query": query})
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        """Return ``(columns, rows, types)`` for the shared cursor.
+
+        `types` is HogQL's list of ``[name, clickhouse_type]`` pairs when present
+        (or None); the cursor turns it into DB-API type codes.
+        """
+        data = self._run_hogql(query)
+        return data.get("columns") or [], data.get("results", []), data.get("types")
+
+    def schema_rows(self) -> list[dict[str, Any]]:
+        """Return HogQL table/column/type rows (via ``DatabaseSchemaQuery``)."""
+        return schema_rows(self)
+
+
+def _rows_from_schema_response(data: dict) -> list[dict[str, Any]]:
+    """Flatten a DatabaseSchemaQuery reply into table/column/type rows.
+
+    Raises ``ValueError`` on any shape we don't recognise.
+    """
+    tables = data.get("tables")
+    if not isinstance(tables, dict) or not tables:
+        raise ValueError("DatabaseSchemaQuery response has no 'tables' mapping")
+
+    rows: list[dict[str, Any]] = []
+    for table_key, table_info in tables.items():
+        if not isinstance(table_info, dict):
+            raise ValueError(f"table {table_key!r} is not an object")
+        table_name = table_info.get("name", table_key)
+        fields = table_info.get("fields")
+        if not isinstance(fields, dict):
+            raise ValueError(f"table {table_key!r} has no 'fields' mapping")
+        for field_key, field_info in fields.items():
+            if isinstance(field_info, dict):
+                column = field_info.get("name", field_key)
+                type_ = field_info.get("type")
+            else:
+                column, type_ = field_key, None
+            rows.append(
+                {
+                    "table": str(table_name),
+                    "column": str(column),
+                    "type": None if type_ is None else str(type_),
+                }
+            )
+
+    if not rows:
+        raise ValueError("DatabaseSchemaQuery response contained no columns")
+    return rows
+
+
+def schema_rows(conn: Any) -> list[dict[str, Any]]:
+    """Return table/column/type rows for the connection.
+
+    Propagates HTTP errors and raises ``ValueError`` on an unexpected response
+    shape — no fallback, no silent degradation.
+    """
+    data = conn._run_query({"kind": "DatabaseSchemaQuery"})
+    return _rows_from_schema_response(data)

--- a/src/moutils/db/posthog.py
+++ b/src/moutils/db/posthog.py
@@ -6,9 +6,14 @@ import requests
 
 from ._core import Connection
 
+_MAX_PAGE_SIZE = 50_000
+
 
 class PostHogConnection(Connection):
-    """Connect to a PostHog project with a personal API key."""
+    """Connect to a PostHog project with a personal API key.
+
+    ``page_size`` caps each query result and must be from 1 through 50,000.
+    """
 
     dialect = "clickhouse"
 
@@ -16,10 +21,17 @@ class PostHogConnection(Connection):
         self,
         api_key: str,
         project_id: str | int,
+        *,
+        page_size: int,
         host: str = "https://us.posthog.com",
     ) -> None:
+        if isinstance(page_size, bool) or not isinstance(page_size, int):
+            raise TypeError("page_size must be an integer")
+        if not 1 <= page_size <= _MAX_PAGE_SIZE:
+            raise ValueError(f"page_size must be between 1 and {_MAX_PAGE_SIZE:,}")
         self._api_key = api_key
         self._project_id = str(project_id)  # accept int, normalise for the URL
+        self._page_size = page_size
         self._host = host.rstrip("/")
 
     def _run_query(self, query: dict) -> dict:
@@ -39,7 +51,9 @@ class PostHogConnection(Connection):
         return data
 
     def _run_hogql(self, query: str) -> dict:
-        return self._run_query({"kind": "HogQLQuery", "query": query})
+        query = query.strip().rstrip(";").rstrip()
+        paged_query = f"SELECT * FROM ({query}) AS moutils_page LIMIT {self._page_size}"
+        return self._run_query({"kind": "HogQLQuery", "query": paged_query})
 
     def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
         """Return columns, rows, and types for the shared cursor."""

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -1,16 +1,4 @@
-"""Fixtures for the moutils.db connector tests.
-
-PostHog fixtures are frozen canned responses (no network, no account). Datasette
-has two flavours:
-
-* Mocked unit tests use ``httpx_mock`` (pytest-httpx) with canned JSON, mirroring
-  the PostHog ``responses`` tests.
-* The ``live_conn`` fixture wires a real, **in-process** Datasette instance:
-  outbound ``httpx`` requests from the connector are intercepted by pytest-httpx
-  and routed into Datasette's own ASGI test client (``ds.client``), which runs
-  real SQL against a real temp SQLite database. No mocked responses, no socket,
-  no subprocess — only the wire is bypassed.
-"""
+"""Shared fixtures for the database connection tests."""
 
 import asyncio
 import sqlite3
@@ -135,8 +123,12 @@ def live_conn(httpx_mock, ds):
         loop.close()
 
 
-# The token the authed in-process instance accepts (see `ds_authed`).
-LIVE_TOKEN = "s3cret-test-token"
+_LIVE_TOKEN = "s3cret-test-token"
+
+
+@pytest.fixture
+def live_token():
+    return _LIVE_TOKEN
 
 
 @pytest.fixture
@@ -144,7 +136,7 @@ def ds_authed(sample_db):
     """In-process Datasette locked down with datasette-auth-tokens.
 
     Anonymous requests are denied (`allow: {id: "*"}` requires an authenticated
-    actor); a request bearing LIVE_TOKEN authenticates as actor `demo`.
+    actor). The test token authenticates as actor ``demo``.
     """
     return Datasette(
         [str(sample_db)],
@@ -152,7 +144,7 @@ def ds_authed(sample_db):
             "allow": {"id": "*"},
             "plugins": {
                 "datasette-auth-tokens": {
-                    "tokens": [{"token": LIVE_TOKEN, "actor": {"id": "demo"}}]
+                    "tokens": [{"token": _LIVE_TOKEN, "actor": {"id": "demo"}}]
                 }
             },
         },

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 from datasette.app import Datasette
 
-from moutils.db import DatasetteConnection
+from moutils.db.datasette import DatasetteConnection
 
 # ---------------------------------------------------------------------------
 # PostHog fixtures — frozen DatabaseSchemaQuery / HogQLQuery replies.

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -1,0 +1,189 @@
+"""Fixtures for the moutils.db connector tests.
+
+PostHog fixtures are frozen canned responses (no network, no account). Datasette
+has two flavours:
+
+* Mocked unit tests use ``httpx_mock`` (pytest-httpx) with canned JSON, mirroring
+  the PostHog ``responses`` tests.
+* The ``live_conn`` fixture wires a real, **in-process** Datasette instance:
+  outbound ``httpx`` requests from the connector are intercepted by pytest-httpx
+  and routed into Datasette's own ASGI test client (``ds.client``), which runs
+  real SQL against a real temp SQLite database. No mocked responses, no socket,
+  no subprocess — only the wire is bypassed.
+"""
+
+import asyncio
+import sqlite3
+
+import httpx
+import pytest
+from datasette.app import Datasette
+
+from moutils.db import DatasetteConnection
+
+# ---------------------------------------------------------------------------
+# PostHog fixtures — frozen DatabaseSchemaQuery / HogQLQuery replies.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hogql_result():
+    """A representative HogQLQuery response with columns + types + results."""
+    return {
+        "columns": ["date", "n"],
+        "types": [["date", "Date"], ["n", "UInt64"]],
+        "results": [
+            ["2026-01-01", 5],
+            ["2026-01-02", 8],
+            ["2026-01-03", 3],
+            ["2026-01-04", 1],
+            ["2026-01-05", 9],
+        ],
+    }
+
+
+@pytest.fixture
+def schema_response():
+    """A frozen DatabaseSchemaQuery reply covering two tables."""
+    return {
+        "tables": {
+            "events": {
+                "name": "events",
+                "fields": {
+                    "uuid": {"name": "uuid", "type": "string"},
+                    "event": {"name": "event", "type": "string"},
+                    "timestamp": {"name": "timestamp", "type": "datetime"},
+                    "properties": {"name": "properties", "type": "json"},
+                },
+            },
+            "persons": {
+                "name": "persons",
+                "fields": {
+                    "id": {"name": "id", "type": "string"},
+                    "created_at": {"name": "created_at", "type": "datetime"},
+                },
+            },
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Datasette fixtures — mocked + in-process live.
+# ---------------------------------------------------------------------------
+
+# The connector points at a non-localhost host so pytest-httpx intercepts it;
+# Datasette's own client stays on localhost (see non_mocked_hosts) and passes
+# through to the real ASGI app.
+_CONNECTOR_HOST = "http://datasette.test"
+_DB_NAME = "sample"
+
+
+@pytest.fixture
+def sample_db(tmp_path):
+    """A temp SQLite db with two tables of known data."""
+    path = tmp_path / f"{_DB_NAME}.db"
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        create table dogs (id integer primary key, name text, age integer);
+        insert into dogs (name, age) values ('Cleo', 5), ('Pancakes', 3);
+        create table cats (id integer primary key, nickname text);
+        insert into cats (nickname) values ('Mr Whiskers');
+        """
+    )
+    con.commit()
+    con.close()
+    return path
+
+
+@pytest.fixture
+def ds(sample_db):
+    return Datasette([str(sample_db)])
+
+
+@pytest.fixture
+def non_mocked_hosts():
+    # Let Datasette's internal ds.client (localhost) reach the real ASGI app.
+    return ["localhost"]
+
+
+@pytest.fixture
+def live_conn(httpx_mock, ds):
+    """A DatasetteConnection whose httpx calls hit the in-process Datasette."""
+    loop = asyncio.new_event_loop()
+
+    def route(request: httpx.Request) -> httpx.Response:
+        async def run():
+            resp = await ds.client.request(
+                request.method,
+                request.url.raw_path.decode("ascii"),  # path + query string
+            )
+            return httpx.Response(
+                status_code=resp.status_code,
+                headers=resp.headers,
+                content=resp.content,
+            )
+
+        return loop.run_until_complete(run())
+
+    httpx_mock.add_callback(route, is_reusable=True)
+    conn = DatasetteConnection(_CONNECTOR_HOST, _DB_NAME)
+    try:
+        yield conn
+    finally:
+        conn.close()
+        loop.close()
+
+
+# The token the authed in-process instance accepts (see `ds_authed`).
+LIVE_TOKEN = "s3cret-test-token"
+
+
+@pytest.fixture
+def ds_authed(sample_db):
+    """In-process Datasette locked down with datasette-auth-tokens.
+
+    Anonymous requests are denied (`allow: {id: "*"}` requires an authenticated
+    actor); a request bearing LIVE_TOKEN authenticates as actor `demo`.
+    """
+    return Datasette(
+        [str(sample_db)],
+        metadata={
+            "allow": {"id": "*"},
+            "plugins": {
+                "datasette-auth-tokens": {
+                    "tokens": [{"token": LIVE_TOKEN, "actor": {"id": "demo"}}]
+                }
+            },
+        },
+    )
+
+
+@pytest.fixture
+def route_authed(httpx_mock, ds_authed):
+    """Route connector calls into the authed instance, forwarding the token."""
+    loop = asyncio.new_event_loop()
+
+    def route(request: httpx.Request) -> httpx.Response:
+        async def run():
+            headers = {}
+            if "authorization" in request.headers:
+                headers["authorization"] = request.headers["authorization"]
+            resp = await ds_authed.client.request(
+                request.method,
+                request.url.raw_path.decode("ascii"),
+                headers=headers,
+            )
+            return httpx.Response(
+                status_code=resp.status_code,
+                headers=resp.headers,
+                content=resp.content,
+            )
+
+        return loop.run_until_complete(run())
+
+    httpx_mock.add_callback(route, is_reusable=True)
+    try:
+        yield
+    finally:
+        loop.close()

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -1,0 +1,122 @@
+"""Generic cursor parsing + paging — connector-agnostic, no HTTP.
+
+Feeds canned ``(columns, rows, types)`` triples through a minimal fake connection
+built on ``moutils.db.Connection`` so this exercises the shared cursor directly.
+"""
+
+import pytest
+
+from moutils.db import Connection
+
+
+class FakeConnection(Connection):
+    """A Connection whose ``_fetch`` returns a fixed triple."""
+
+    dialect = "fake"
+
+    def __init__(self, triple):
+        self._triple = triple
+
+    def _fetch(self, query):
+        return self._triple
+
+
+def cursor_for(triple):
+    return FakeConnection(triple).cursor()
+
+
+@pytest.fixture
+def five_rows():
+    return (
+        ["date", "n"],
+        [
+            ["2026-01-01", 5],
+            ["2026-01-02", 8],
+            ["2026-01-03", 3],
+            ["2026-01-04", 1],
+            ["2026-01-05", 9],
+        ],
+        [["date", "Date"], ["n", "UInt64"]],
+    )
+
+
+def test_description_from_columns_and_types():
+    cur = cursor_for(
+        (["date", "n"], [["2026-01-01", 5]], [["date", "Date"], ["n", "UInt64"]])
+    ).execute("SELECT 1")
+
+    assert len(cur.description) == 2
+    for desc in cur.description:
+        assert len(desc) == 7  # DB-API 2.0 7-tuple
+    assert [d[0] for d in cur.description] == ["date", "n"]
+    assert [d[1] for d in cur.description] == ["Date", "UInt64"]
+    for desc in cur.description:
+        assert desc[2:] == (None, None, None, None, None)
+
+
+def test_description_names_are_str():
+    cur = cursor_for(([1, 2], [], [["a", "Int64"], ["b", "Int64"]])).execute("SELECT 1")
+    assert [d[0] for d in cur.description] == ["1", "2"]
+
+
+def test_types_none_gives_none_type_codes():
+    cur = cursor_for((["a", "b"], [["x", "y"]], None)).execute("SELECT 1")
+    assert [d[1] for d in cur.description] == [None, None]
+
+
+def test_bare_string_type_passes_through():
+    # A `types` entry that's a bare string (not a [name, type] pair) is passed
+    # through unchanged — exercises the isinstance/len>1 branch.
+    cur = cursor_for((["a", "b"], [], ["Int64", ["b", "String"]])).execute("SELECT 1")
+    assert [d[1] for d in cur.description] == ["Int64", "String"]
+
+
+def test_rowcount_matches_rows(five_rows):
+    cur = cursor_for(five_rows).execute("SELECT 1")
+    assert cur.rowcount == 5
+
+
+def test_paging_shares_pos(five_rows):
+    cur = cursor_for(five_rows).execute("SELECT 1")
+    assert cur.arraysize == 1
+
+    assert cur.fetchone() == ["2026-01-01", 5]
+    assert cur.fetchmany() == [["2026-01-02", 8]]  # arraysize == 1
+    assert cur.fetchmany(3) == [
+        ["2026-01-03", 3],
+        ["2026-01-04", 1],
+        ["2026-01-05", 9],
+    ]
+    assert cur.fetchall() == []  # nothing left
+    assert cur.fetchone() is None
+
+
+def test_fetchall_returns_from_current_pos(five_rows):
+    cur = cursor_for(five_rows).execute("SELECT 1")
+    cur.fetchone()
+    assert cur.fetchall() == [
+        ["2026-01-02", 8],
+        ["2026-01-03", 3],
+        ["2026-01-04", 1],
+        ["2026-01-05", 9],
+    ]
+
+
+def test_close_empties_rows_and_resets_pos(five_rows):
+    cur = cursor_for(five_rows).execute("SELECT 1")
+    cur.fetchone()
+    cur.close()
+    assert cur.fetchall() == []
+    assert cur.fetchone() is None
+
+
+def test_parameters_guard_raises(five_rows):
+    cur = cursor_for(five_rows)
+    with pytest.raises(NotImplementedError):
+        cur.execute("SELECT 1", parameters=[1])
+
+
+def test_parameters_none_or_empty_ok(five_rows):
+    cur = cursor_for(five_rows)
+    cur.execute("SELECT 1", parameters=None)
+    cur.execute("SELECT 1", parameters=[])  # empty is falsy -> allowed

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -6,7 +6,7 @@ built on ``moutils.db.Connection`` so this exercises the shared cursor directly.
 
 import pytest
 
-from moutils.db import Connection
+from moutils.db._core import Connection
 
 
 class FakeConnection(Connection):

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -20,6 +20,9 @@ class FakeConnection(Connection):
     def _fetch(self, query):
         return self._triple
 
+    def schema_rows(self):
+        return []
+
 
 def cursor_for(triple):
     return FakeConnection(triple).cursor()
@@ -120,3 +123,15 @@ def test_parameters_none_or_empty_ok(five_rows):
     cur = cursor_for(five_rows)
     cur.execute("SELECT 1", parameters=None)
     cur.execute("SELECT 1", parameters=[])  # empty is falsy -> allowed
+
+
+def test_connection_is_abstract():
+    # A subclass missing a hook can't be instantiated (Connection is an ABC).
+    class Incomplete(Connection):
+        dialect = "fake"
+
+        def _fetch(self, query):  # schema_rows still missing
+            return ([], [], None)
+
+    with pytest.raises(TypeError):
+        Incomplete()

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -1,8 +1,4 @@
-"""Generic cursor parsing + paging — connector-agnostic, no HTTP.
-
-Feeds canned ``(columns, rows, types)`` triples through a minimal fake connection
-built on ``moutils.db.Connection`` so this exercises the shared cursor directly.
-"""
+"""Tests for the shared cursor."""
 
 import pytest
 
@@ -74,6 +70,12 @@ def test_bare_string_type_passes_through():
     assert [d[1] for d in cur.description] == ["Int64", "String"]
 
 
+def test_missing_type_keeps_column_in_description():
+    cur = cursor_for((["a", "b"], [[1, 2]], ["Int64"])).execute("SELECT 1")
+    assert [d[0] for d in cur.description] == ["a", "b"]
+    assert [d[1] for d in cur.description] == ["Int64", None]
+
+
 def test_rowcount_matches_rows(five_rows):
     cur = cursor_for(five_rows).execute("SELECT 1")
     assert cur.rowcount == 5
@@ -115,7 +117,7 @@ def test_close_empties_rows_and_resets_pos(five_rows):
 
 def test_parameters_guard_raises(five_rows):
     cur = cursor_for(five_rows)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="do not support bound parameters"):
         cur.execute("SELECT 1", parameters=[1])
 
 

--- a/tests/db/test_datasette_connection.py
+++ b/tests/db/test_datasette_connection.py
@@ -1,4 +1,4 @@
-"""HTTP contract — verified with pytest-httpx (real request-building, no socket)."""
+"""Tests for the Datasette HTTP contract."""
 
 import httpx
 import pytest
@@ -28,7 +28,33 @@ def test_execute_builds_request_and_parses(httpx_mock):
     assert str(req.url).startswith("http://ds.test/content.json")
     assert req.url.params["sql"] == "select id, name from dogs"
     assert req.url.params["_shape"] == "arrays"
+    assert req.url.params["_extra"] == "columns"
     assert req.headers["Authorization"] == "Bearer sekret"
+
+
+def test_execute_follows_datasette_1_query_redirect(httpx_mock):
+    httpx_mock.add_response(
+        status_code=302,
+        headers={
+            "Location": "/content/-/query.json?sql=select+1&_shape=arrays&_extra=columns"
+        },
+    )
+    httpx_mock.add_response(
+        json={"ok": True, "columns": ["n"], "rows": [[1]], "truncated": False}
+    )
+
+    conn = DatasetteConnection("http://ds.test", "content", token="sekret")
+    assert conn.cursor().execute("select 1").fetchall() == [[1]]
+
+    requests = httpx_mock.get_requests()
+    assert requests[1].url.path == "/content/-/query.json"
+    assert requests[1].headers["Authorization"] == "Bearer sekret"
+
+
+def test_database_route_is_url_encoded(httpx_mock):
+    httpx_mock.add_response(json={"ok": True, "columns": [], "rows": []})
+    DatasetteConnection("http://ds.test", "one/two").cursor().execute("select 1")
+    assert httpx_mock.get_requests()[0].url.raw_path.startswith(b"/one%2Ftwo.json")
 
 
 def test_no_token_omits_auth_and_strips_trailing_slash(httpx_mock):
@@ -50,6 +76,12 @@ def test_truncated_emits_warning(httpx_mock):
     conn = DatasetteConnection("http://ds.test", "content")
     with pytest.warns(UserWarning, match="truncated"):
         conn.cursor().execute("select 1")
+
+
+def test_bad_query_shape_raises(httpx_mock):
+    httpx_mock.add_response(json={"ok": True, "rows": []})
+    with pytest.raises(ValueError, match="query response shape"):
+        DatasetteConnection("http://ds.test", "content").cursor().execute("select 1")
 
 
 @pytest.mark.parametrize("status", [400, 500])

--- a/tests/db/test_datasette_connection.py
+++ b/tests/db/test_datasette_connection.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 
-from moutils.db import DatasetteConnection
+from moutils.db.datasette import DatasetteConnection
 
 
 def test_execute_builds_request_and_parses(httpx_mock):

--- a/tests/db/test_datasette_connection.py
+++ b/tests/db/test_datasette_connection.py
@@ -1,0 +1,69 @@
+"""HTTP contract — verified with pytest-httpx (real request-building, no socket)."""
+
+import httpx
+import pytest
+
+from moutils.db import DatasetteConnection
+
+
+def test_execute_builds_request_and_parses(httpx_mock):
+    httpx_mock.add_response(
+        json={
+            "ok": True,
+            "columns": ["id", "name"],
+            "rows": [[1, "Cleo"], [2, "Pancakes"]],
+            "truncated": False,
+        },
+    )
+    conn = DatasetteConnection("http://ds.test", "content", token="sekret")
+    cur = conn.cursor().execute("select id, name from dogs")
+
+    assert [d[0] for d in cur.description] == ["id", "name"]
+    # SQLite results carry no per-column types -> None type codes.
+    assert [d[1] for d in cur.description] == [None, None]
+    assert cur.fetchall() == [[1, "Cleo"], [2, "Pancakes"]]
+
+    req = httpx_mock.get_requests()[0]
+    assert req.method == "GET"
+    assert str(req.url).startswith("http://ds.test/content.json")
+    assert req.url.params["sql"] == "select id, name from dogs"
+    assert req.url.params["_shape"] == "arrays"
+    assert req.headers["Authorization"] == "Bearer sekret"
+
+
+def test_no_token_omits_auth_and_strips_trailing_slash(httpx_mock):
+    httpx_mock.add_response(json={"ok": True, "columns": [], "rows": []})
+    conn = DatasetteConnection("http://ds.test/", "content")  # trailing slash
+    conn.cursor().execute("select 1")
+
+    req = httpx_mock.get_requests()[0]
+    assert "authorization" not in req.headers
+    url = str(req.url)
+    assert url.startswith("http://ds.test/content.json")
+    assert "//content" not in url
+
+
+def test_truncated_emits_warning(httpx_mock):
+    httpx_mock.add_response(
+        json={"ok": True, "columns": ["n"], "rows": [[1]], "truncated": True},
+    )
+    conn = DatasetteConnection("http://ds.test", "content")
+    with pytest.warns(UserWarning, match="truncated"):
+        conn.cursor().execute("select 1")
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_http_error_propagates(httpx_mock, status):
+    httpx_mock.add_response(status_code=status, json={"ok": False, "error": "boom"})
+    with pytest.raises(httpx.HTTPStatusError):
+        DatasetteConnection("http://ds.test", "content").cursor().execute("select bad")
+
+
+def test_commit_rollback_are_noops():
+    conn = DatasetteConnection("http://ds.test", "content")
+    assert conn.commit() is None
+    assert conn.rollback() is None
+
+
+def test_dialect_is_sqlite():
+    assert DatasetteConnection("http://ds.test", "content").dialect == "sqlite"

--- a/tests/db/test_datasette_introspect.py
+++ b/tests/db/test_datasette_introspect.py
@@ -1,5 +1,6 @@
 """Tests for Datasette database discovery."""
 
+import httpx
 import pytest
 
 from moutils.db.datasette import DatasetteConnection, databases
@@ -49,5 +50,27 @@ def test_for_database_opens_sibling_with_same_url_and_token():
     assert other.database_name == "everest"
     assert other._base_url == "http://ds.test"
     assert other._token == "t"
-    conn.close()
+    assert other._client is conn._client
+    assert not other._owns_client
+
     other.close()
+    assert not conn._client.is_closed
+    conn.close()
+    assert conn._client.is_closed
+
+
+def test_for_database_preserves_caller_provided_client():
+    client = httpx.Client(headers={"X-Test": "configured"}, timeout=7)
+    conn = DatasetteConnection(
+        "http://ds.test", "earthquakes", token="t", client=client
+    )
+    other = conn.for_database("everest")
+
+    assert other._client is client
+    assert other._client.headers["X-Test"] == "configured"
+    assert other._client.timeout.connect == 7
+
+    other.close()
+    conn.close()
+    assert not client.is_closed
+    client.close()

--- a/tests/db/test_datasette_introspect.py
+++ b/tests/db/test_datasette_introspect.py
@@ -1,0 +1,40 @@
+"""Instance introspection: enumerate databases via /-/databases.json."""
+
+from moutils.db import DatasetteConnection, databases
+
+_DBS = [
+    {"name": "earthquakes", "route": "earthquakes", "is_memory": False},
+    {"name": "everest", "route": "everest", "is_memory": False},
+    {"name": "_memory", "route": "_memory", "is_memory": True},  # skipped
+]
+
+
+def test_databases_lists_routes_and_skips_memory(httpx_mock):
+    httpx_mock.add_response(json=_DBS)
+    assert databases("http://ds.test/") == ["earthquakes", "everest"]
+    assert str(httpx_mock.get_requests()[0].url) == "http://ds.test/-/databases.json"
+
+
+def test_databases_sends_token(httpx_mock):
+    httpx_mock.add_response(json=_DBS)
+    databases("http://ds.test", token="sekret")
+    assert httpx_mock.get_requests()[0].headers["Authorization"] == "Bearer sekret"
+
+
+def test_connection_discovers_siblings(httpx_mock):
+    # Discovery reachable from a single connection, carrying its own token.
+    httpx_mock.add_response(json=_DBS)
+    conn = DatasetteConnection("http://ds.test", "earthquakes", token="t")
+    assert conn.databases() == ["earthquakes", "everest"]
+    assert httpx_mock.get_requests()[0].headers["Authorization"] == "Bearer t"
+
+
+def test_for_database_opens_sibling_with_same_url_and_token():
+    conn = DatasetteConnection("http://ds.test/", "earthquakes", token="t")
+    other = conn.for_database("everest")
+    assert isinstance(other, DatasetteConnection)
+    assert other.database_name == "everest"
+    assert other._base_url == "http://ds.test"
+    assert other._token == "t"
+    conn.close()
+    other.close()

--- a/tests/db/test_datasette_introspect.py
+++ b/tests/db/test_datasette_introspect.py
@@ -1,4 +1,6 @@
-"""Instance introspection: enumerate databases via /-/databases.json."""
+"""Tests for Datasette database discovery."""
+
+import pytest
 
 from moutils.db.datasette import DatasetteConnection, databases
 
@@ -13,6 +15,17 @@ def test_databases_lists_routes_and_skips_memory(httpx_mock):
     httpx_mock.add_response(json=_DBS)
     assert databases("http://ds.test/") == ["earthquakes", "everest"]
     assert str(httpx_mock.get_requests()[0].url) == "http://ds.test/-/databases.json"
+
+
+def test_databases_accepts_datasette_1_envelope(httpx_mock):
+    httpx_mock.add_response(json={"ok": True, "databases": _DBS})
+    assert databases("http://ds.test") == ["earthquakes", "everest"]
+
+
+def test_databases_rejects_bad_shape(httpx_mock):
+    httpx_mock.add_response(json={"ok": True})
+    with pytest.raises(ValueError, match="databases response shape"):
+        databases("http://ds.test")
 
 
 def test_databases_sends_token(httpx_mock):

--- a/tests/db/test_datasette_introspect.py
+++ b/tests/db/test_datasette_introspect.py
@@ -1,6 +1,6 @@
 """Instance introspection: enumerate databases via /-/databases.json."""
 
-from moutils.db import DatasetteConnection, databases
+from moutils.db.datasette import DatasetteConnection, databases
 
 _DBS = [
     {"name": "earthquakes", "route": "earthquakes", "is_memory": False},

--- a/tests/db/test_datasette_live.py
+++ b/tests/db/test_datasette_live.py
@@ -1,0 +1,42 @@
+"""End-to-end against a REAL, in-process Datasette instance — no mocked JSON.
+
+The ``live_conn`` fixture (see conftest) routes the connector's real httpx calls
+into Datasette's own ASGI test client, which executes real SQL against a real
+temp SQLite database. This is the payoff of choosing Datasette: the whole stack
+(request building, the query engine, response parsing) runs for real locally.
+"""
+
+import httpx
+import pytest
+
+
+def test_execute_real(live_conn):
+    cur = live_conn.cursor().execute("select id, name, age from dogs order by id")
+    assert [d[0] for d in cur.description] == ["id", "name", "age"]
+    assert cur.fetchall() == [[1, "Cleo", 5], [2, "Pancakes", 3]]
+
+
+def test_fetchone_paging_real(live_conn):
+    cur = live_conn.cursor().execute("select name from dogs order by id")
+    assert cur.fetchone() == ["Cleo"]
+    assert cur.fetchone() == ["Pancakes"]
+    assert cur.fetchone() is None
+
+
+def test_schema_rows_real(live_conn):
+    rows = live_conn.schema_rows()
+    assert {"table": "dogs", "column": "name", "type": "TEXT"} in rows
+    assert {"table": "dogs", "column": "age", "type": "INTEGER"} in rows
+    assert {r["table"] for r in rows} == {"dogs", "cats"}
+
+
+def test_sql_error_real(live_conn):
+    with pytest.raises(httpx.HTTPStatusError):
+        live_conn.cursor().execute("select * from does_not_exist")
+
+
+def test_databases_real(live_conn):
+    # live_conn activates routing into the in-process Datasette (serving one db).
+    from moutils.db import databases
+
+    assert databases("http://datasette.test") == ["sample"]

--- a/tests/db/test_datasette_live.py
+++ b/tests/db/test_datasette_live.py
@@ -37,6 +37,6 @@ def test_sql_error_real(live_conn):
 
 def test_databases_real(live_conn):
     # live_conn activates routing into the in-process Datasette (serving one db).
-    from moutils.db import databases
+    from moutils.db.datasette import databases
 
     assert databases("http://datasette.test") == ["sample"]

--- a/tests/db/test_datasette_live.py
+++ b/tests/db/test_datasette_live.py
@@ -1,10 +1,4 @@
-"""End-to-end against a REAL, in-process Datasette instance — no mocked JSON.
-
-The ``live_conn`` fixture (see conftest) routes the connector's real httpx calls
-into Datasette's own ASGI test client, which executes real SQL against a real
-temp SQLite database. This is the payoff of choosing Datasette: the whole stack
-(request building, the query engine, response parsing) runs for real locally.
-"""
+"""End-to-end tests with an in-process Datasette instance."""
 
 import httpx
 import pytest

--- a/tests/db/test_datasette_live_auth.py
+++ b/tests/db/test_datasette_live_auth.py
@@ -1,15 +1,9 @@
-"""Token auth against a REAL, in-process Datasette locked with datasette-auth-tokens.
-
-Confirms end-to-end that the connector's `token` (sent as `Authorization: Bearer
-<token>`) is what actually unlocks a protected instance — no mocked responses.
-"""
+"""End-to-end tests for Datasette token authentication."""
 
 import httpx
 import pytest
 
 from moutils.db.datasette import DatasetteConnection
-
-from .conftest import LIVE_TOKEN
 
 _HOST = "http://datasette.test"
 _DB = "sample"
@@ -31,8 +25,8 @@ def test_wrong_token_is_denied(route_authed):
     conn.close()
 
 
-def test_correct_token_grants_access(route_authed):
-    conn = DatasetteConnection(_HOST, _DB, token=LIVE_TOKEN)
+def test_correct_token_grants_access(route_authed, live_token):
+    conn = DatasetteConnection(_HOST, _DB, token=live_token)
     assert conn.cursor().execute("select name from dogs order by id").fetchall() == [
         ["Cleo"],
         ["Pancakes"],

--- a/tests/db/test_datasette_live_auth.py
+++ b/tests/db/test_datasette_live_auth.py
@@ -7,7 +7,7 @@ Confirms end-to-end that the connector's `token` (sent as `Authorization: Bearer
 import httpx
 import pytest
 
-from moutils.db import DatasetteConnection
+from moutils.db.datasette import DatasetteConnection
 
 from .conftest import LIVE_TOKEN
 

--- a/tests/db/test_datasette_live_auth.py
+++ b/tests/db/test_datasette_live_auth.py
@@ -1,0 +1,41 @@
+"""Token auth against a REAL, in-process Datasette locked with datasette-auth-tokens.
+
+Confirms end-to-end that the connector's `token` (sent as `Authorization: Bearer
+<token>`) is what actually unlocks a protected instance — no mocked responses.
+"""
+
+import httpx
+import pytest
+
+from moutils.db import DatasetteConnection
+
+from .conftest import LIVE_TOKEN
+
+_HOST = "http://datasette.test"
+_DB = "sample"
+
+
+def test_no_token_is_denied(route_authed):
+    conn = DatasetteConnection(_HOST, _DB)  # no token
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        conn.cursor().execute("select 1")
+    assert exc.value.response.status_code == 403
+    conn.close()
+
+
+def test_wrong_token_is_denied(route_authed):
+    conn = DatasetteConnection(_HOST, _DB, token="not-the-token")
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        conn.cursor().execute("select 1")
+    assert exc.value.response.status_code == 403
+    conn.close()
+
+
+def test_correct_token_grants_access(route_authed):
+    conn = DatasetteConnection(_HOST, _DB, token=LIVE_TOKEN)
+    assert conn.cursor().execute("select name from dogs order by id").fetchall() == [
+        ["Cleo"],
+        ["Pancakes"],
+    ]
+    assert {"table": "dogs", "column": "name", "type": "TEXT"} in conn.schema_rows()
+    conn.close()

--- a/tests/db/test_datasette_schema.py
+++ b/tests/db/test_datasette_schema.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from moutils.db import DatasetteConnection
+from moutils.db.datasette import DatasetteConnection
 
 
 def _schema_response(rows):

--- a/tests/db/test_datasette_schema.py
+++ b/tests/db/test_datasette_schema.py
@@ -1,4 +1,4 @@
-"""Schema discovery — pragma-based parsing; fails early on unexpected shape."""
+"""Tests for Datasette schema discovery."""
 
 import pytest
 

--- a/tests/db/test_datasette_schema.py
+++ b/tests/db/test_datasette_schema.py
@@ -1,0 +1,46 @@
+"""Schema discovery — pragma-based parsing; fails early on unexpected shape."""
+
+import pytest
+
+from moutils.db import DatasetteConnection
+
+
+def _schema_response(rows):
+    return {
+        "ok": True,
+        "columns": ["table", "column", "type"],
+        "rows": rows,
+        "truncated": False,
+    }
+
+
+def test_schema_rows_parses(httpx_mock):
+    httpx_mock.add_response(
+        json=_schema_response(
+            [
+                ["dogs", "id", "INTEGER"],
+                ["dogs", "name", "TEXT"],
+                ["cats", "nickname", "TEXT"],
+            ]
+        )
+    )
+    rows = DatasetteConnection("http://ds.test", "content").schema_rows()
+
+    assert {"table": "dogs", "column": "id", "type": "INTEGER"} in rows
+    assert {r["table"] for r in rows} == {"dogs", "cats"}
+    assert len(rows) == 3
+
+    # outbound query uses the table-valued pragma introspection.
+    req = httpx_mock.get_requests()[0]
+    assert "pragma_table_info" in req.url.params["sql"]
+
+
+def test_schema_bad_shape_raises(httpx_mock):
+    httpx_mock.add_response(json={"ok": True, "columns": ["x"], "rows": [["y"]]})
+    with pytest.raises(ValueError):
+        DatasetteConnection("http://ds.test", "content").schema_rows()
+
+
+def test_empty_schema_is_ok(httpx_mock):
+    httpx_mock.add_response(json=_schema_response([]))
+    assert DatasetteConnection("http://ds.test", "content").schema_rows() == []

--- a/tests/db/test_posthog_connection.py
+++ b/tests/db/test_posthog_connection.py
@@ -19,13 +19,20 @@ def test_execute_builds_request_and_parses():
             "results": [["2026-01-01", 5]],
         },
     )
-    cur = PostHogConnection(api_key="k", project_id=42).cursor().execute("SELECT 1")
+    cur = (
+        PostHogConnection(api_key="k", project_id=42, page_size=1_000)
+        .cursor()
+        .execute("SELECT 1")
+    )
     assert [d[0] for d in cur.description] == ["date", "n"]
     assert [d[1] for d in cur.description] == ["Date", "UInt64"]
     assert cur.fetchall() == [["2026-01-01", 5]]
 
     body = json.loads(responses.calls[0].request.body)
-    assert body["query"] == {"kind": "HogQLQuery", "query": "SELECT 1"}
+    assert body["query"] == {
+        "kind": "HogQLQuery",
+        "query": "SELECT * FROM (SELECT 1) AS moutils_page LIMIT 1000",
+    }
     req = responses.calls[0].request
     assert req.headers["Authorization"] == "Bearer k"
     assert req.headers["Content-Type"] == "application/json"
@@ -37,7 +44,9 @@ def test_int_project_id_in_url():
         "https://us.posthog.com/api/projects/123/query/",
         json={"columns": [], "results": []},
     )
-    PostHogConnection(api_key="k", project_id=123).cursor().execute("SELECT 1")
+    PostHogConnection(api_key="k", project_id=123, page_size=1_000).cursor().execute(
+        "SELECT 1"
+    )
     assert (
         responses.calls[0].request.url
         == "https://us.posthog.com/api/projects/123/query/"
@@ -50,7 +59,12 @@ def test_host_trailing_slash_stripped():
         "https://eu.posthog.com/api/projects/7/query/",
         json={"columns": [], "results": []},
     )
-    conn = PostHogConnection(api_key="k", project_id=7, host="https://eu.posthog.com/")
+    conn = PostHogConnection(
+        api_key="k",
+        project_id=7,
+        page_size=1_000,
+        host="https://eu.posthog.com/",
+    )
     conn.cursor().execute("SELECT 1")
     url = responses.calls[0].request.url
     assert url == "https://eu.posthog.com/api/projects/7/query/"
@@ -66,7 +80,9 @@ def test_http_error_propagates(status):
         status=status,
     )
     with pytest.raises(requests.HTTPError):
-        PostHogConnection(api_key="bad", project_id=42).cursor().execute("SELECT 1")
+        PostHogConnection(
+            api_key="bad", project_id=42, page_size=1_000
+        ).cursor().execute("SELECT 1")
 
 
 @responses.activate
@@ -76,15 +92,59 @@ def test_bad_query_shape_raises():
         json={"columns": ["n"]},
     )
     with pytest.raises(ValueError, match="query response shape"):
-        PostHogConnection(api_key="k", project_id=42).cursor().execute("SELECT 1")
+        PostHogConnection(api_key="k", project_id=42, page_size=1_000).cursor().execute(
+            "SELECT 1"
+        )
+
+
+@responses.activate
+def test_page_size_caps_query_with_limit():
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json={"columns": [], "results": []},
+    )
+    PostHogConnection(api_key="k", project_id=42, page_size=500).cursor().execute(
+        "SELECT * FROM events LIMIT 10;"
+    )
+
+    body = json.loads(responses.calls[0].request.body)
+    assert body["query"]["query"] == (
+        "SELECT * FROM (SELECT * FROM events LIMIT 10) AS moutils_page LIMIT 500"
+    )
+
+
+def test_page_size_is_required():
+    with pytest.raises(TypeError, match="page_size"):
+        PostHogConnection(api_key="k", project_id=42)  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize("page_size", [True, 1.5, "100"])
+def test_page_size_must_be_an_integer(page_size):
+    with pytest.raises(TypeError, match="page_size must be an integer"):
+        PostHogConnection(api_key="k", project_id=42, page_size=page_size)
+
+
+@pytest.mark.parametrize("page_size", [-1, 0, 50_001])
+def test_page_size_must_be_in_range(page_size):
+    with pytest.raises(ValueError, match="page_size must be between 1 and 50,000"):
+        PostHogConnection(api_key="k", project_id=42, page_size=page_size)
+
+
+@pytest.mark.parametrize("page_size", [1, 50_000])
+def test_page_size_accepts_boundaries(page_size):
+    conn = PostHogConnection(api_key="k", project_id=42, page_size=page_size)
+    assert conn._page_size == page_size
 
 
 def test_commit_rollback_close_are_noops():
-    conn = PostHogConnection(api_key="k", project_id=1)
+    conn = PostHogConnection(api_key="k", project_id=1, page_size=1_000)
     assert conn.commit() is None
     assert conn.rollback() is None
     assert conn.close() is None
 
 
 def test_dialect_is_clickhouse():
-    assert PostHogConnection(api_key="k", project_id=1).dialect == "clickhouse"
+    assert (
+        PostHogConnection(api_key="k", project_id=1, page_size=1_000).dialect
+        == "clickhouse"
+    )

--- a/tests/db/test_posthog_connection.py
+++ b/tests/db/test_posthog_connection.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 import responses
 
-from moutils.db import PostHogConnection
+from moutils.db.posthog import PostHogConnection
 
 
 @responses.activate

--- a/tests/db/test_posthog_connection.py
+++ b/tests/db/test_posthog_connection.py
@@ -1,0 +1,80 @@
+"""HTTP contract — verified with `responses` (real request-building, no network)."""
+
+import json
+
+import pytest
+import requests
+import responses
+
+from moutils.db import PostHogConnection
+
+
+@responses.activate
+def test_execute_builds_request_and_parses():
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json={
+            "columns": ["date", "n"],
+            "types": [["date", "Date"], ["n", "UInt64"]],
+            "results": [["2026-01-01", 5]],
+        },
+    )
+    cur = PostHogConnection(api_key="k", project_id=42).cursor().execute("SELECT 1")
+    assert [d[0] for d in cur.description] == ["date", "n"]
+    assert [d[1] for d in cur.description] == ["Date", "UInt64"]
+    assert cur.fetchall() == [["2026-01-01", 5]]
+
+    body = json.loads(responses.calls[0].request.body)
+    assert body["query"] == {"kind": "HogQLQuery", "query": "SELECT 1"}
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == "Bearer k"
+    assert req.headers["Content-Type"] == "application/json"
+
+
+@responses.activate
+def test_int_project_id_in_url():
+    responses.post(
+        "https://us.posthog.com/api/projects/123/query/",
+        json={"columns": [], "results": []},
+    )
+    PostHogConnection(api_key="k", project_id=123).cursor().execute("SELECT 1")
+    assert (
+        responses.calls[0].request.url
+        == "https://us.posthog.com/api/projects/123/query/"
+    )
+
+
+@responses.activate
+def test_host_trailing_slash_stripped():
+    responses.post(
+        "https://eu.posthog.com/api/projects/7/query/",
+        json={"columns": [], "results": []},
+    )
+    conn = PostHogConnection(api_key="k", project_id=7, host="https://eu.posthog.com/")
+    conn.cursor().execute("SELECT 1")
+    url = responses.calls[0].request.url
+    assert url == "https://eu.posthog.com/api/projects/7/query/"
+    assert "//api" not in url
+
+
+@responses.activate
+@pytest.mark.parametrize("status", [401, 500])
+def test_http_error_propagates(status):
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json={"detail": "nope"},
+        status=status,
+    )
+    with pytest.raises(requests.HTTPError):
+        PostHogConnection(api_key="bad", project_id=42).cursor().execute("SELECT 1")
+
+
+def test_commit_rollback_close_are_noops():
+    conn = PostHogConnection(api_key="k", project_id=1)
+    assert conn.commit() is None
+    assert conn.rollback() is None
+    assert conn.close() is None
+
+
+def test_dialect_is_clickhouse():
+    assert PostHogConnection(api_key="k", project_id=1).dialect == "clickhouse"

--- a/tests/db/test_posthog_connection.py
+++ b/tests/db/test_posthog_connection.py
@@ -1,4 +1,4 @@
-"""HTTP contract — verified with `responses` (real request-building, no network)."""
+"""Tests for the PostHog HTTP contract."""
 
 import json
 
@@ -67,6 +67,16 @@ def test_http_error_propagates(status):
     )
     with pytest.raises(requests.HTTPError):
         PostHogConnection(api_key="bad", project_id=42).cursor().execute("SELECT 1")
+
+
+@responses.activate
+def test_bad_query_shape_raises():
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json={"columns": ["n"]},
+    )
+    with pytest.raises(ValueError, match="query response shape"):
+        PostHogConnection(api_key="k", project_id=42).cursor().execute("SELECT 1")
 
 
 def test_commit_rollback_close_are_noops():

--- a/tests/db/test_posthog_schema.py
+++ b/tests/db/test_posthog_schema.py
@@ -6,8 +6,11 @@ import pytest
 import requests
 import responses
 
-from moutils.db import PostHogConnection
-from moutils.db.posthog import _rows_from_schema_response, schema_rows
+from moutils.db.posthog import (
+    PostHogConnection,
+    _rows_from_schema_response,
+    schema_rows,
+)
 
 
 @responses.activate

--- a/tests/db/test_posthog_schema.py
+++ b/tests/db/test_posthog_schema.py
@@ -1,4 +1,4 @@
-"""Schema discovery — DatabaseSchemaQuery parsing; fails early, no fallback."""
+"""Tests for PostHog schema discovery."""
 
 import json
 

--- a/tests/db/test_posthog_schema.py
+++ b/tests/db/test_posthog_schema.py
@@ -19,7 +19,7 @@ def test_schema_rows_from_database_schema_query(schema_response):
         "https://us.posthog.com/api/projects/42/query/",
         json=schema_response,
     )
-    rows = schema_rows(PostHogConnection(api_key="k", project_id=42))
+    rows = schema_rows(PostHogConnection(api_key="k", project_id=42, page_size=1_000))
 
     # outbound body is the schema-query kind
     body = json.loads(responses.calls[0].request.body)
@@ -40,7 +40,7 @@ def test_http_error_propagates():
         status=500,
     )
     with pytest.raises(requests.HTTPError):
-        schema_rows(PostHogConnection(api_key="k", project_id=42))
+        schema_rows(PostHogConnection(api_key="k", project_id=42, page_size=1_000))
 
 
 @responses.activate
@@ -50,7 +50,7 @@ def test_garbage_shape_raises():
         json={"unexpected": "shape"},
     )
     with pytest.raises(ValueError):
-        schema_rows(PostHogConnection(api_key="k", project_id=42))
+        schema_rows(PostHogConnection(api_key="k", project_id=42, page_size=1_000))
 
 
 @pytest.mark.parametrize(
@@ -80,6 +80,6 @@ def test_connection_schema_rows_method(schema_response):
         "https://us.posthog.com/api/projects/42/query/",
         json=schema_response,
     )
-    rows = PostHogConnection(api_key="k", project_id=42).schema_rows()
+    rows = PostHogConnection(api_key="k", project_id=42, page_size=1_000).schema_rows()
     assert {r["table"] for r in rows} == {"events", "persons"}
     assert len(rows) == 6

--- a/tests/db/test_posthog_schema.py
+++ b/tests/db/test_posthog_schema.py
@@ -1,0 +1,82 @@
+"""Schema discovery — DatabaseSchemaQuery parsing; fails early, no fallback."""
+
+import json
+
+import pytest
+import requests
+import responses
+
+from moutils.db import PostHogConnection
+from moutils.db.posthog import _rows_from_schema_response, schema_rows
+
+
+@responses.activate
+def test_schema_rows_from_database_schema_query(schema_response):
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json=schema_response,
+    )
+    rows = schema_rows(PostHogConnection(api_key="k", project_id=42))
+
+    # outbound body is the schema-query kind
+    body = json.loads(responses.calls[0].request.body)
+    assert body["query"] == {"kind": "DatabaseSchemaQuery"}
+
+    assert {"table": "events", "column": "uuid", "type": "string"} in rows
+    assert {"table": "events", "column": "properties", "type": "json"} in rows
+    assert {"table": "persons", "column": "id", "type": "string"} in rows
+    assert {r["table"] for r in rows} == {"events", "persons"}
+    assert len(rows) == 6  # 4 event fields + 2 person fields
+
+
+@responses.activate
+def test_http_error_propagates():
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json={"detail": "boom"},
+        status=500,
+    )
+    with pytest.raises(requests.HTTPError):
+        schema_rows(PostHogConnection(api_key="k", project_id=42))
+
+
+@responses.activate
+def test_garbage_shape_raises():
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json={"unexpected": "shape"},
+    )
+    with pytest.raises(ValueError):
+        schema_rows(PostHogConnection(api_key="k", project_id=42))
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {},
+        {"tables": {}},
+        {"tables": {"events": "not-an-object"}},
+        {"tables": {"events": {"name": "events"}}},  # no fields
+        {"tables": {"events": {"fields": {}}}},  # empty fields -> no columns
+    ],
+)
+def test_rows_from_schema_response_rejects(bad):
+    with pytest.raises(ValueError):
+        _rows_from_schema_response(bad)
+
+
+def test_field_without_type_gives_none():
+    data = {"tables": {"t": {"fields": {"c": {}}}}}
+    rows = _rows_from_schema_response(data)
+    assert rows == [{"table": "t", "column": "c", "type": None}]
+
+
+@responses.activate
+def test_connection_schema_rows_method(schema_response):
+    responses.post(
+        "https://us.posthog.com/api/projects/42/query/",
+        json=schema_response,
+    )
+    rows = PostHogConnection(api_key="k", project_id=42).schema_rows()
+    assert {r["table"] for r in rows} == {"events", "persons"}
+    assert len(rows) == 6

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -36,6 +45,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/5e/cbea445bf062b81e4d366ca29dae4f0aedc7a64f384afc24670e07bec560/anywidget-0.9.21.tar.gz", hash = "sha256:b8d0172029ac426573053c416c6a587838661612208bb390fa0607862e594b27", size = 390517, upload-time = "2025-11-12T17:06:03.035Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/03/c17464bbf682ea87e7e3de2ddc63395e359a78ae9c01f55fc78759ecbd79/anywidget-0.9.21-py3-none-any.whl", hash = "sha256:78c268e0fbdb1dfd15da37fb578f9cf0a0df58a430e68d9156942b7a9391a761", size = 231797, upload-time = "2025-11-12T17:06:01.564Z" },
+]
+
+[[package]]
+name = "asgi-csrf"
+version = "0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "itsdangerous" },
+    { name = "python-multipart" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/59/2b54a274b9c9cbe1c0edbe5d324925ffd88a31567fb50dc2138e0160bdef/asgi_csrf-0.11.tar.gz", hash = "sha256:e19a4f87d5af3feabde04c57921ee15510c3bfb0565627df9cb20bcb303282c2", size = 14044, upload-time = "2024-11-15T01:05:45.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/1c/5d954baaf144852a4762368b37c06202b277378ea412acc5565f69acc9e9/asgi_csrf-0.11-py3-none-any.whl", hash = "sha256:03ac140115f39d4295288a9adf74fdc6ae607f6ef44abee8466520458207242b", size = 11704, upload-time = "2024-11-15T01:05:43.483Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -126,6 +157,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click-default-group"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/ce/edb087fb53de63dad3b36408ca30368f438738098e668b78c87f93cd41df/click_default_group-1.2.4.tar.gz", hash = "sha256:eb3f3c99ec0d456ca6cd2a7f08f7d4e91771bef51b01bdd9580cc6450fe1251e", size = 3505, upload-time = "2023-08-04T07:54:58.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/1a/aff8bb287a4b1400f69e09a53bd65de96aa5cee5691925b38731c67fc695/click_default_group-1.2.4-py2.py3-none-any.whl", hash = "sha256:9b60486923720e7fc61731bdb32b617039aba820e22e1c88766b1125592eaa5f", size = 4123, upload-time = "2023-08-04T07:54:56.875Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -141,6 +184,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "datasette"
+version = "0.65.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "asgi-csrf" },
+    { name = "asgiref" },
+    { name = "click" },
+    { name = "click-default-group" },
+    { name = "flexcache" },
+    { name = "flexparser" },
+    { name = "httpx" },
+    { name = "hupper" },
+    { name = "itsdangerous" },
+    { name = "janus" },
+    { name = "jinja2" },
+    { name = "mergedeep" },
+    { name = "pip" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/26/80b5480921d71891b8ff880fed6d44150b9164903d683efe2eb7405b61d8/datasette-0.65.2.tar.gz", hash = "sha256:be956fb2633b8380d7f818b5ddab40d5c7346d5e9d4d24e81c43b1fb60267432", size = 410536, upload-time = "2025-11-05T18:23:25.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/3a/ffa1259fc018f3bb0e6e8444982909a449478ede805def5593319ff3f732/datasette-0.65.2-py3-none-any.whl", hash = "sha256:d4f342a5c86d073bbb1880a9df792354cae4f951e427b57586713eff1896507f", size = 397412, upload-time = "2025-11-05T18:23:23.916Z" },
+]
+
+[[package]]
+name = "datasette-auth-tokens"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/e8/9232738f0a0e825be9dec92244b1fb48ec897b04dbd599237cf1e3239319/datasette-auth-tokens-0.3.tar.gz", hash = "sha256:526ce6f150e729e51c6df283238c58885a437eeb90d80a12357d4a454ba6f36e", size = 8254, upload-time = "2021-10-15T00:58:50.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/20/7da7b8970560a98a7b604cddeb4ec834681f5778de5f8ec893d71b991a8a/datasette_auth_tokens-0.3-py3-none-any.whl", hash = "sha256:6318fa366e3c7d98f0e1f09f1918fab45b51d46087585642aa369627a612bd42", size = 8752, upload-time = "2021-10-15T00:58:49.076Z" },
 ]
 
 [[package]]
@@ -180,6 +266,30 @@ wheels = [
 ]
 
 [[package]]
+name = "flexcache"
+version = "0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816, upload-time = "2024-03-09T03:21:07.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263, upload-time = "2024-03-09T03:21:05.635Z" },
+]
+
+[[package]]
+name = "flexparser"
+version = "0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/99/b4de7e39e8eaf8207ba1a8fa2241dd98b2ba72ae6e16960d8351736d8702/flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2", size = 31799, upload-time = "2024-11-07T02:00:56.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846", size = 27625, upload-time = "2024-11-07T02:00:54.523Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -214,6 +324,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hupper"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e6/bb064537288eee2be97f3e0fcad8e7242bc5bbe9664ae57c7d29b3fa18c2/hupper-1.12.1.tar.gz", hash = "sha256:06bf54170ff4ecf4c84ad5f188dee3901173ab449c2608ad05b9bfd6b13e32eb", size = 43231, upload-time = "2024-01-26T09:14:57.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/7d/3888833e4f5ea56af4a9935066ec09a83228e533d7b8877f65889d706ee4/hupper-1.12.1-py3-none-any.whl", hash = "sha256:e872b959f09d90be5fb615bd2e62de89a0b57efc037bdf9637fb09cdf8552b19", size = 22830, upload-time = "2024-01-26T09:14:55.176Z" },
 ]
 
 [[package]]
@@ -293,6 +412,15 @@ wheels = [
 ]
 
 [[package]]
+name = "janus"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/7f/69884b6618be4baf6ebcacc716ee8680a842428a19f403db6d1c0bb990aa/janus-2.0.0.tar.gz", hash = "sha256:0970f38e0e725400496c834a368a67ee551dc3b5ad0a257e132f5b46f2e77770", size = 22910, upload-time = "2024-12-13T12:59:08.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/34/65604740edcb20e1bda6a890348ed7d282e7dd23aa00401cbe36fd0edbd9/janus-2.0.0-py3-none-any.whl", hash = "sha256:7e6449d34eab04cd016befbd7d8c0d8acaaaab67cb59e076a69149f9031745f9", size = 12161, upload-time = "2024-12-13T12:59:06.106Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +430,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -486,6 +626,69 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -498,6 +701,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
 name = "moutils"
 version = "0.4.4"
 source = { editable = "." }
@@ -507,28 +719,42 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+db = [
+    { name = "httpx" },
+]
 dev = [
     { name = "marimo" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "datasette" },
+    { name = "datasette-auth-tokens" },
+    { name = "httpx" },
     { name = "marimo" },
     { name = "pytest" },
+    { name = "pytest-httpx" },
+    { name = "responses" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.0" },
+    { name = "httpx", marker = "extra == 'db'", specifier = ">=0.27" },
     { name = "marimo", marker = "extra == 'dev'" },
     { name = "requests", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "db"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "datasette", specifier = ">=0.64,<1" },
+    { name = "datasette-auth-tokens", specifier = ">=0.3,<0.4" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "marimo" },
     { name = "pytest" },
+    { name = "pytest-httpx", specifier = ">=0.30" },
+    { name = "responses", specifier = ">=0.25" },
 ]
 
 [[package]]
@@ -627,6 +853,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -845,6 +1089,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpx"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -903,6 +1169,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds read-only PostHog and Datasette connections for marimo SQL cells:

```python
from moutils.db.datasette import DatasetteConnection
from moutils.db.posthog import PostHogConnection
```

- `PostHogConnection` runs HogQL through the PostHog query API.
- `DatasetteConnection` runs SQLite SQL against one Datasette database.
- Both connections expose the DB-API-shaped interface that marimo detects.
- `schema_rows()` returns table, column, and type metadata.

The shared `Connection` and `Cursor` classes remain internal.

## Installation

PostHog uses the base `requests` dependency. Datasette requires `httpx`:

```sh
pip install "moutils[db]"
```

The module imports `httpx` only when a Datasette connection needs it.

## Compatibility and safety

- Supports the Datasette 0.x query URL and the Datasette 1.x redirect.
- Supports both Datasette database-list response formats.
- Reuses the configured HTTP client across Datasette sibling connections.
- Requires a PostHog `page_size` from 1 through 50,000 and caps each query.
- Rejects malformed PostHog and Datasette responses with clear errors.
- Rejects bound parameters without recommending unsafe SQL interpolation.

## Validation

```sh
uv run pytest -ra
uvx pre-commit run -a
uv build
```

The full suite passes with 138 tests. The database suite contains 68 unit and in-process integration tests.
