### PR TITLE
feat(db): add non-DBAPI connection wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ moutils.screenshot(locator="#my-chart", filename="chart.png")
 
 ## Database connections
 
-`moutils.db` provides read-only REST connections for marimo SQL cells. Import a
+`moutils.db` provides DB-API-compatible adapters for marimo SQL cells. Import a
 connection and assign it to a notebook variable. marimo detects the variable as
 a SQL engine.
 
@@ -291,6 +291,13 @@ a SQL engine.
 |------------|-------------|
 | `PostHogConnection` | Query a PostHog project via its HogQL API (`clickhouse` dialect) |
 | `DatasetteConnection` | Query one database of a [Datasette](https://datasette.io) instance (`sqlite` dialect) |
+| `D1Connection` | Query a Cloudflare D1 database through its REST API |
+| `ElasticsearchConnection` | Query Elasticsearch through its SQL API |
+| `OpenSearchConnection` | Query OpenSearch through its SQL plugin |
+| `TimestreamConnection` | Query Amazon Timestream for LiveAnalytics |
+| `DuneConnection` | Execute raw DuneSQL through `dune-client` |
+| `QueryConnection` | Adapt any `query(sql)` callable that returns tabular data |
+| `ConnectorXConnection` | Adapt `connectorx.read_sql` with inferred dialects |
 
 `PostHogConnection` uses the base `requests` dependency. Install the optional
 `db` dependency for `DatasetteConnection`:
@@ -337,8 +344,107 @@ SELECT * FROM tables LIMIT 10
 A connection uses one database. Use `datasette.databases()` to list the database
 routes. Use `datasette.for_database("everest")` to connect to another database.
 
+### QueryConnection
+
+Use `QueryConnection` when a client already has a function that accepts SQL and
+returns records, a result tuple, or a pandas, Polars, or PyArrow table:
+
+```python
+from moutils.db.query import QueryConnection
+
+warehouse = QueryConnection(
+    lambda sql: client.query(sql),
+    dialect="postgres",
+)
+```
+
+### ConnectorXConnection
+
+```sh
+pip install connectorx pandas
+```
+
+```python
+from moutils.db.connectorx import ConnectorXConnection
+
+warehouse = ConnectorXConnection("postgresql://user:pass@host/database")
+```
+
+The SQL dialect is inferred from recognized connection URL schemes. Pass
+`dialect=` explicitly for federated or custom URLs. Extra keyword arguments are
+forwarded to `connectorx.read_sql`. Install Polars separately when using
+`return_type="polars"`.
+
+### Cloudflare D1
+
+```python
+from moutils.db.d1 import D1Connection
+
+d1 = D1Connection(
+    account_id="...",
+    database_id="...",
+    api_token="...",  # Prefer a token with only D1 Read permission.
+)
+```
+
+### Elasticsearch and OpenSearch
+
+The adapters wrap configured official clients and follow SQL result cursors to
+retrieve every page:
+
+```sh
+pip install elasticsearch opensearch-py
+```
+
+```python
+from elasticsearch import Elasticsearch
+from moutils.db.elasticsearch import ElasticsearchConnection
+
+elastic = ElasticsearchConnection(Elasticsearch("https://localhost:9200"))
+```
+
+```python
+from opensearchpy import OpenSearch
+from moutils.db.opensearch import OpenSearchConnection
+
+opensearch = OpenSearchConnection(OpenSearch("https://localhost:9200"))
+```
+
+### Amazon Timestream
+
+```sh
+pip install boto3
+```
+
+```python
+import boto3
+from moutils.db.timestream import TimestreamConnection
+
+timestream = TimestreamConnection(boto3.client("timestream-query"))
+```
+
+The adapter follows `NextToken` pages and decodes scalar and nested Timestream
+values.
+
+### Dune
+
+```sh
+pip install dune-client
+```
+
+```python
+from dune_client.client import DuneClient
+from moutils.db.dune import DuneConnection
+
+dune = DuneConnection(DuneClient.from_env())
+```
+
+The adapter submits raw DuneSQL, waits for completion, and retrieves every
+result page.
+
 These connections do not support bound parameters. Use static or trusted SQL.
-Do not insert untrusted values into SQL strings.
+Do not insert untrusted values into SQL strings. Provider adapters that receive
+an existing client leave that client open by default.
 
 ## Development
 

--- a/src/moutils/db/__init__.py
+++ b/src/moutils/db/__init__.py
@@ -1,14 +1,16 @@
-"""Read-only REST connections for marimo SQL cells.
+"""DB-API-compatible adapters for marimo SQL cells.
 
 Import a connection from its submodule. Then assign it to a notebook variable:
 
     from moutils.db.posthog import PostHogConnection
     from moutils.db.datasette import DatasetteConnection
+    from moutils.db.query import QueryConnection
 
     posthog = PostHogConnection(
         api_key="phx_...", project_id=123, page_size=10_000
     )
     datasette = DatasetteConnection("https://example.com", "mydb")
+    custom = QueryConnection(my_query_function, dialect="sqlite")
 
-PostHog uses ``requests``. Datasette requires the ``db`` optional dependency.
+Import provider adapters from their modules so optional SDKs stay optional.
 """

--- a/src/moutils/db/_core.py
+++ b/src/moutils/db/_core.py
@@ -1,4 +1,4 @@
-"""Shared DB-API-compatible classes for the REST connections."""
+"""Shared DB-API-compatible classes for marimo query adapters."""
 
 from abc import ABC, abstractmethod
 from typing import Any, Sequence
@@ -77,17 +77,17 @@ class Cursor:
 
 
 class Connection(ABC):
-    """Base class for read-only REST connections."""
+    """Base class for marimo-compatible query connections."""
 
     dialect: str = ""
 
     def cursor(self) -> Cursor:
         return Cursor(self)
 
-    def commit(self) -> None:  # no-op: moutils.db connectors are read-only
+    def commit(self) -> None:  # no-op: adapters do not manage transactions
         pass
 
-    def rollback(self) -> None:  # no-op: moutils.db connectors are read-only
+    def rollback(self) -> None:  # no-op: adapters do not manage transactions
         pass
 
     def close(self) -> None:
@@ -97,6 +97,11 @@ class Connection(ABC):
     def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
         """Return ``(columns, rows, types | None)`` for the shared cursor."""
 
-    @abstractmethod
     def schema_rows(self) -> list[dict[str, Any]]:
-        """Return ``{"table", "column", "type"}`` rows describing the schema."""
+        """Return ``{"table", "column", "type"}`` rows describing the schema.
+
+        Schema discovery is optional because marimo's generic DB-API engine does
+        not currently consume it. Connections with a cheap metadata endpoint can
+        override this method for callers that want to inspect the source directly.
+        """
+        return []

--- a/src/moutils/db/_dependencies.py
+++ b/src/moutils/db/_dependencies.py
@@ -1,0 +1,28 @@
+"""Helpers for optional database client dependencies."""
+
+from importlib import import_module
+from types import ModuleType
+
+
+def require_dependency(
+    module_name: str,
+    *,
+    connection_name: str,
+    package_name: str | None = None,
+) -> ModuleType:
+    """Import an optional dependency or raise an actionable error.
+
+    Imports are attempted on every call. In particular, this function does not
+    cache failures so a package installed during a notebook session is available
+    when the connection is constructed again.
+    """
+    try:
+        return import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name != module_name.split(".", 1)[0]:
+            raise
+        install_name = package_name or module_name
+        raise ImportError(
+            f"{connection_name} requires `{install_name}`. "
+            f"Install it with `pip install {install_name}`."
+        ) from exc

--- a/src/moutils/db/connectorx.py
+++ b/src/moutils/db/connectorx.py
@@ -1,0 +1,72 @@
+"""Tiny marimo connection adapter for :mod:`connectorx`."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib.parse import urlsplit
+
+from ._dependencies import require_dependency
+from .query import QueryConnection
+
+_DIALECTS = {
+    "bigquery": "bigquery",
+    "clickhouse": "clickhouse",
+    "mariadb": "mysql",
+    "mssql": "tsql",
+    "mysql": "mysql",
+    "oracle": "oracle",
+    "postgres": "postgres",
+    "postgresql": "postgres",
+    "redshift": "redshift",
+    "sqlite": "sqlite",
+}
+
+
+def _infer_dialect(connection: Any) -> str | None:
+    if isinstance(connection, str):
+        return _DIALECTS.get(urlsplit(connection).scheme.lower())
+    return None
+
+
+class ConnectorXConnection(QueryConnection):
+    """Run SQL through ``connectorx.read_sql`` with minimal syntax."""
+
+    def __init__(
+        self,
+        connection: str | Mapping[str, str],
+        *,
+        dialect: str | None = None,
+        return_type: str = "pandas",
+        schema: Callable[[], list[dict[str, Any]]] | None = None,
+        **read_sql_options: Any,
+    ) -> None:
+        resolved_dialect = dialect or _infer_dialect(connection)
+        if resolved_dialect is None:
+            raise ValueError(
+                "dialect is required for federated or unrecognized connection URLs"
+            )
+
+        connectorx = require_dependency(
+            "connectorx", connection_name="ConnectorXConnection"
+        )
+        if return_type == "pandas":
+            require_dependency("pandas", connection_name="ConnectorXConnection")
+        elif return_type == "polars":
+            require_dependency("polars", connection_name="ConnectorXConnection")
+        elif return_type in ("arrow", "arrow_stream"):
+            require_dependency(
+                "pyarrow",
+                connection_name="ConnectorXConnection",
+                package_name="pyarrow",
+            )
+
+        def query(sql: str) -> Any:
+            return connectorx.read_sql(
+                connection,
+                sql,
+                return_type=return_type,
+                **read_sql_options,
+            )
+
+        super().__init__(query, dialect=resolved_dialect, schema=schema)

--- a/src/moutils/db/d1.py
+++ b/src/moutils/db/d1.py
@@ -1,0 +1,96 @@
+"""Marimo SQL connection for Cloudflare D1's REST API."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+from ._core import Connection
+
+_SCHEMA_SQL = (
+    'select m.name as "table", p.name as "column", p.type as "type" '
+    "from sqlite_schema m join pragma_table_info(m.name) p "
+    "where m.type = 'table' and m.name not like 'sqlite_%' "
+    "order by m.name, p.cid"
+)
+
+
+class D1Connection(Connection):
+    """Connect to one Cloudflare D1 database over HTTP.
+
+    Use an API token with only the ``D1 Read`` permission when the connection
+    should be read-only.
+    """
+
+    dialect = "sqlite"
+
+    def __init__(
+        self,
+        account_id: str,
+        database_id: str,
+        api_token: str,
+        *,
+        session: requests.Session | None = None,
+        base_url: str = "https://api.cloudflare.com/client/v4",
+    ) -> None:
+        self._account_id = account_id
+        self._database_id = database_id
+        self._api_token = api_token
+        self._base_url = base_url.rstrip("/")
+        self._owns_session = session is None
+        self._session = session or requests.Session()
+
+    def _run_sql(self, query: str) -> dict[str, Any]:
+        account = quote(self._account_id, safe="")
+        database = quote(self._database_id, safe="")
+        response = self._session.post(
+            f"{self._base_url}/accounts/{account}/d1/database/{database}/raw",
+            headers={
+                "Authorization": f"Bearer {self._api_token}",
+                "Content-Type": "application/json",
+            },
+            json={"sql": query},
+            timeout=120,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):
+            raise ValueError("unexpected D1 response: expected an object")
+        if data.get("success") is not True:
+            raise ValueError(f"D1 query failed: {data.get('errors', [])!r}")
+        results = data.get("result")
+        if not isinstance(results, list) or len(results) != 1:
+            raise ValueError("D1 connection requires exactly one SQL statement")
+        result = results[0]
+        if not isinstance(result, dict) or result.get("success") is not True:
+            raise ValueError("D1 statement failed")
+        return result
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        result = self._run_sql(query).get("results")
+        if not isinstance(result, dict):
+            raise ValueError("unexpected D1 result shape")
+        columns = result.get("columns")
+        rows = result.get("rows")
+        if not isinstance(columns, list) or not isinstance(rows, list):
+            raise ValueError("unexpected D1 rows or columns")
+        return columns, rows, None
+
+    def schema_rows(self) -> list[dict[str, Any]]:
+        columns, rows, _ = self._fetch(_SCHEMA_SQL)
+        if columns != ["table", "column", "type"]:
+            raise ValueError(f"unexpected D1 schema columns: {columns!r}")
+        return [
+            {
+                "table": str(table),
+                "column": str(column),
+                "type": None if type_ is None else str(type_),
+            }
+            for table, column, type_ in rows
+        ]
+
+    def close(self) -> None:
+        if self._owns_session:
+            self._session.close()

--- a/src/moutils/db/dune.py
+++ b/src/moutils/db/dune.py
@@ -1,0 +1,107 @@
+"""Marimo SQL connection for the Dune API Python client."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from ._core import Connection
+from ._dependencies import require_dependency
+
+_TERMINAL_STATES = {
+    "QUERY_STATE_CANCELLED",
+    "QUERY_STATE_COMPLETED",
+    "QUERY_STATE_COMPLETED_PARTIAL",
+    "QUERY_STATE_EXPIRED",
+    "QUERY_STATE_FAILED",
+}
+_SUCCESS_STATES = {"QUERY_STATE_COMPLETED", "QUERY_STATE_COMPLETED_PARTIAL"}
+
+
+def _state_value(state: Any) -> str:
+    return str(getattr(state, "value", state))
+
+
+class DuneConnection(Connection):
+    """Execute raw DuneSQL through an existing ``DuneClient``."""
+
+    dialect = "trino"
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        performance: str | None = None,
+        poll_interval: float = 1,
+        timeout: float | None = None,
+        batch_size: int = 32_000,
+    ) -> None:
+        require_dependency(
+            "dune_client",
+            connection_name="DuneConnection",
+            package_name="dune-client",
+        )
+        if poll_interval < 0:
+            raise ValueError("poll_interval cannot be negative")
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be positive")
+        if isinstance(batch_size, bool) or not isinstance(batch_size, int):
+            raise TypeError("batch_size must be an integer")
+        if batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        self._client = client
+        self._performance = performance
+        self._poll_interval = poll_interval
+        self._timeout = timeout
+        self._batch_size = batch_size
+
+    def _wait(self, execution_id: str) -> None:
+        deadline = None if self._timeout is None else time.monotonic() + self._timeout
+        while True:
+            status = self._client.get_execution_status(execution_id)
+            state = _state_value(status.state)
+            if state in _TERMINAL_STATES:
+                if state not in _SUCCESS_STATES:
+                    error = getattr(status, "error", None)
+                    message = getattr(error, "message", None) or state
+                    raise RuntimeError(f"Dune query failed: {message}")
+                return
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(f"Dune query {execution_id} timed out")
+            time.sleep(self._poll_interval)
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        execution = self._client.execute_sql(
+            query_sql=query,
+            performance=self._performance,
+        )
+        execution_id = execution.execution_id
+        self._wait(execution_id)
+
+        offset = 0
+        columns: list[Any] | None = None
+        types: list[Any] | None = None
+        rows: list[Any] = []
+        while True:
+            response = self._client.get_execution_results(
+                execution_id,
+                limit=self._batch_size,
+                offset=offset,
+            )
+            result = response.result
+            if result is None:
+                raise ValueError("Dune completed without a result")
+            metadata = result.metadata
+            if columns is None:
+                columns = list(metadata.column_names)
+                types = list(metadata.column_types)
+            for record in result.rows:
+                if not isinstance(record, Mapping):
+                    raise ValueError("unexpected Dune row shape")
+                rows.append([record.get(column) for column in columns])
+            next_offset = response.next_offset
+            if next_offset is None:
+                break
+            offset = next_offset
+        return columns, rows, types

--- a/src/moutils/db/elasticsearch.py
+++ b/src/moutils/db/elasticsearch.py
@@ -1,0 +1,75 @@
+"""Marimo SQL connection for the Elasticsearch Python client."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ._core import Connection
+from ._dependencies import require_dependency
+
+
+def _body(response: Any) -> Mapping[str, Any]:
+    body = getattr(response, "body", response)
+    if not isinstance(body, Mapping):
+        raise ValueError("unexpected Elasticsearch response shape")
+    return body
+
+
+class ElasticsearchConnection(Connection):
+    """Run Elasticsearch SQL through an existing ``Elasticsearch`` client."""
+
+    dialect = "sql"
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        fetch_size: int = 1_000,
+        close_client: bool = False,
+    ) -> None:
+        require_dependency("elasticsearch", connection_name="ElasticsearchConnection")
+        if isinstance(fetch_size, bool) or not isinstance(fetch_size, int):
+            raise TypeError("fetch_size must be an integer")
+        if fetch_size < 1:
+            raise ValueError("fetch_size must be positive")
+        self._client = client
+        self._fetch_size = fetch_size
+        self._close_client = close_client
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        response = self._client.sql.query(query=query, fetch_size=self._fetch_size)
+        columns: list[Any] | None = None
+        types: list[Any] | None = None
+        rows: list[Any] = []
+        cursor: str | None = None
+        try:
+            while True:
+                data = _body(response)
+                if columns is None:
+                    schema = data.get("columns")
+                    if not isinstance(schema, list):
+                        raise ValueError("Elasticsearch response has no columns")
+                    if not all(isinstance(column, Mapping) for column in schema):
+                        raise ValueError("unexpected Elasticsearch columns")
+                    columns = [column.get("name") for column in schema]
+                    types = [column.get("type") for column in schema]
+                page_rows = data.get("rows", [])
+                if not isinstance(page_rows, list):
+                    raise ValueError("unexpected Elasticsearch rows")
+                rows.extend(page_rows)
+                cursor = data.get("cursor")
+                if not cursor:
+                    break
+                response = self._client.sql.query(cursor=cursor)
+            return columns, rows, types
+        finally:
+            if cursor:
+                try:
+                    self._client.sql.clear_cursor(cursor=cursor)
+                except Exception:
+                    pass  # Do not hide the query error with a cleanup failure.
+
+    def close(self) -> None:
+        if self._close_client:
+            self._client.close()

--- a/src/moutils/db/opensearch.py
+++ b/src/moutils/db/opensearch.py
@@ -1,0 +1,80 @@
+"""Marimo SQL connection for the OpenSearch Python client."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ._core import Connection
+from ._dependencies import require_dependency
+
+_SQL_PATH = "/_plugins/_sql"
+
+
+class OpenSearchConnection(Connection):
+    """Run OpenSearch SQL through an existing ``OpenSearch`` client."""
+
+    dialect = "sql"
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        fetch_size: int = 1_000,
+        close_client: bool = False,
+    ) -> None:
+        require_dependency(
+            "opensearchpy",
+            connection_name="OpenSearchConnection",
+            package_name="opensearch-py",
+        )
+        if isinstance(fetch_size, bool) or not isinstance(fetch_size, int):
+            raise TypeError("fetch_size must be an integer")
+        if fetch_size < 1:
+            raise ValueError("fetch_size must be positive")
+        self._client = client
+        self._fetch_size = fetch_size
+        self._close_client = close_client
+
+    def _request(self, body: dict[str, Any], *, path: str = _SQL_PATH) -> Mapping:
+        response = self._client.transport.perform_request("POST", path, body=body)
+        response = getattr(response, "body", response)
+        if not isinstance(response, Mapping):
+            raise ValueError("unexpected OpenSearch response shape")
+        return response
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        data = self._request({"query": query, "fetch_size": self._fetch_size})
+        columns: list[Any] | None = None
+        types: list[Any] | None = None
+        rows: list[Any] = []
+        cursor: str | None = None
+        try:
+            while True:
+                if columns is None:
+                    schema = data.get("schema")
+                    if not isinstance(schema, list) or not all(
+                        isinstance(column, Mapping) for column in schema
+                    ):
+                        raise ValueError("OpenSearch response has no schema")
+                    columns = [column.get("name") for column in schema]
+                    types = [column.get("type") for column in schema]
+                page_rows = data.get("datarows", [])
+                if not isinstance(page_rows, list):
+                    raise ValueError("unexpected OpenSearch rows")
+                rows.extend(page_rows)
+                cursor = data.get("cursor")
+                if not cursor:
+                    break
+                data = self._request({"cursor": cursor})
+            return columns, rows, types
+        finally:
+            if cursor:
+                try:
+                    self._request({"cursor": cursor}, path=f"{_SQL_PATH}/close")
+                except Exception:
+                    pass  # Do not hide the query error with a cleanup failure.
+
+    def close(self) -> None:
+        if self._close_client:
+            self._client.close()

--- a/src/moutils/db/query.py
+++ b/src/moutils/db/query.py
@@ -1,0 +1,123 @@
+"""Adapt a query callable into a marimo-compatible DB-API connection."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ._core import Connection
+
+
+@dataclass(frozen=True)
+class QueryResult:
+    """A provider-independent tabular query result."""
+
+    columns: Sequence[Any]
+    rows: Iterable[Sequence[Any]]
+    types: Sequence[Any] | None = None
+
+
+def _records_result(records: list[Mapping[Any, Any]]) -> QueryResult:
+    if not records:
+        return QueryResult([], [])
+    columns = list(records[0])
+    return QueryResult(
+        columns, ([record.get(column) for column in columns] for record in records)
+    )
+
+
+def normalize_result(result: Any) -> QueryResult:
+    """Normalize common tabular values returned by query libraries.
+
+    Supported values are :class:`QueryResult`, ``(columns, rows[, types])``
+    tuples, mappings with ``columns`` and ``rows`` keys, record mappings,
+    pandas/Polars dataframes, and PyArrow tables.
+    """
+    if isinstance(result, QueryResult):
+        return result
+
+    if isinstance(result, tuple) and len(result) in (2, 3):
+        columns, rows = result[:2]
+        types = result[2] if len(result) == 3 else None
+        return QueryResult(columns, rows, types)
+
+    if isinstance(result, Mapping):
+        if "columns" not in result or "rows" not in result:
+            raise TypeError("query result mapping must contain 'columns' and 'rows'")
+        return QueryResult(result["columns"], result["rows"], result.get("types"))
+
+    # PyArrow Table: to_pylist returns records while schema preserves types.
+    if hasattr(result, "column_names") and callable(getattr(result, "to_pylist", None)):
+        columns = list(result.column_names)
+        records = result.to_pylist()
+        rows = ([record.get(column) for column in columns] for record in records)
+        schema = getattr(result, "schema", None)
+        types = [str(type_) for type_ in schema.types] if schema is not None else None
+        return QueryResult(columns, rows, types)
+
+    columns = getattr(result, "columns", None)
+    if columns is not None:
+        columns = list(columns)
+
+        # Polars DataFrame.
+        rows_method = getattr(result, "rows", None)
+        if callable(rows_method):
+            types = getattr(result, "dtypes", None)
+            return QueryResult(
+                columns,
+                rows_method(),
+                [str(type_) for type_ in types] if types is not None else None,
+            )
+
+        # pandas DataFrame and compatible objects.
+        tuples = getattr(result, "itertuples", None)
+        if callable(tuples):
+            dtypes = getattr(result, "dtypes", None)
+            return QueryResult(
+                columns,
+                tuples(index=False, name=None),
+                [str(type_) for type_ in dtypes] if dtypes is not None else None,
+            )
+
+    if isinstance(result, Iterable) and not isinstance(result, (str, bytes)):
+        records = list(result)
+        if not records:
+            return QueryResult([], [])
+        if all(isinstance(record, Mapping) for record in records):
+            return _records_result(records)
+
+    raise TypeError(
+        "unsupported query result; return QueryResult, a result tuple, records, "
+        "or a pandas, Polars, or PyArrow table"
+    )
+
+
+class QueryConnection(Connection):
+    """Wrap ``query(sql) -> tabular result`` for use in marimo SQL cells."""
+
+    def __init__(
+        self,
+        query: Callable[[str], Any],
+        *,
+        dialect: str = "sql",
+        schema: Callable[[], list[dict[str, Any]]] | None = None,
+        close: Callable[[], Any] | None = None,
+    ) -> None:
+        if not callable(query):
+            raise TypeError("query must be callable")
+        self._query = query
+        self.dialect = dialect
+        self._schema = schema
+        self._close = close
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        result = normalize_result(self._query(query))
+        return list(result.columns), [list(row) for row in result.rows], result.types
+
+    def schema_rows(self) -> list[dict[str, Any]]:
+        return [] if self._schema is None else self._schema()
+
+    def close(self) -> None:
+        if self._close is not None:
+            self._close()

--- a/src/moutils/db/timestream.py
+++ b/src/moutils/db/timestream.py
@@ -1,0 +1,142 @@
+"""Marimo SQL connection for Amazon Timestream for LiveAnalytics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any
+
+from ._core import Connection
+from ._dependencies import require_dependency
+
+_SCHEMA_SQL = (
+    'select table_name as "table", column_name as "column", '
+    'data_type as "type" from information_schema.columns '
+    "order by table_name, ordinal_position"
+)
+
+
+def _type_name(type_info: Mapping[str, Any]) -> str | None:
+    scalar = type_info.get("ScalarType")
+    if scalar:
+        return str(scalar)
+    if "ArrayColumnInfo" in type_info:
+        nested = type_info["ArrayColumnInfo"]
+        return f"ARRAY<{_type_name(nested.get('Type', {}))}>"
+    if "TimeSeriesMeasureValueColumnInfo" in type_info:
+        nested = type_info["TimeSeriesMeasureValueColumnInfo"]
+        return f"TIMESERIES<{_type_name(nested.get('Type', {}))}>"
+    if "RowColumnInfo" in type_info:
+        fields = type_info["RowColumnInfo"]
+        inner = ", ".join(
+            f"{field.get('Name', '')} {_type_name(field.get('Type', {}))}"
+            for field in fields
+        )
+        return f"ROW<{inner}>"
+    return None
+
+
+def _scalar(value: str, scalar_type: str | None) -> Any:
+    if scalar_type == "BOOLEAN":
+        return value.lower() == "true"
+    if scalar_type == "BIGINT":
+        return int(value)
+    if scalar_type == "DOUBLE":
+        return float(value)
+    if scalar_type == "DECIMAL":
+        return Decimal(value)
+    return value
+
+
+def _datum(data: Mapping[str, Any], column: Mapping[str, Any]) -> Any:
+    if data.get("NullValue") is True:
+        return None
+    type_info = column.get("Type", {})
+    if "ScalarValue" in data:
+        return _scalar(data["ScalarValue"], type_info.get("ScalarType"))
+    if "ArrayValue" in data:
+        nested = type_info.get("ArrayColumnInfo", {})
+        return [_datum(value, nested) for value in data["ArrayValue"]]
+    if "RowValue" in data:
+        fields = type_info.get("RowColumnInfo", [])
+        values = data["RowValue"].get("Data", [])
+        return {
+            field.get("Name", str(index)): _datum(value, field)
+            for index, (field, value) in enumerate(zip(fields, values))
+        }
+    if "TimeSeriesValue" in data:
+        nested = type_info.get("TimeSeriesMeasureValueColumnInfo", {})
+        return [
+            {"time": point.get("Time"), "value": _datum(point["Value"], nested)}
+            for point in data["TimeSeriesValue"]
+        ]
+    raise ValueError(f"unexpected Timestream datum: {data!r}")
+
+
+class TimestreamConnection(Connection):
+    """Run SQL through an existing boto3 ``timestream-query`` client."""
+
+    dialect = "trino"
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        page_size: int = 1_000,
+        close_client: bool = False,
+    ) -> None:
+        require_dependency("boto3", connection_name="TimestreamConnection")
+        if isinstance(page_size, bool) or not isinstance(page_size, int):
+            raise TypeError("page_size must be an integer")
+        if not 1 <= page_size <= 1_000:
+            raise ValueError("page_size must be between 1 and 1,000")
+        self._client = client
+        self._page_size = page_size
+        self._close_client = close_client
+
+    def _fetch(self, query: str) -> tuple[list[Any], list[Any], Any]:
+        request: dict[str, Any] = {
+            "QueryString": query,
+            "MaxRows": self._page_size,
+        }
+        columns: list[Any] | None = None
+        types: list[Any] | None = None
+        rows: list[Any] = []
+        while True:
+            response = self._client.query(**request)
+            schema = response.get("ColumnInfo")
+            if columns is None:
+                if not isinstance(schema, list):
+                    raise ValueError("Timestream response has no ColumnInfo")
+                columns = [column.get("Name", "") for column in schema]
+                types = [_type_name(column.get("Type", {})) for column in schema]
+            if not isinstance(schema, list):
+                schema = []
+            page_rows = response.get("Rows", [])
+            if not isinstance(page_rows, list):
+                raise ValueError("unexpected Timestream rows")
+            for row in page_rows:
+                values = row.get("Data") if isinstance(row, Mapping) else None
+                if not isinstance(values, list) or len(values) != len(schema):
+                    raise ValueError("unexpected Timestream row shape")
+                rows.append(
+                    [_datum(value, column) for value, column in zip(values, schema)]
+                )
+            token = response.get("NextToken")
+            if not token:
+                break
+            request["NextToken"] = token
+        return columns, rows, types
+
+    def schema_rows(self) -> list[dict[str, Any]]:
+        columns, rows, _ = self._fetch(_SCHEMA_SQL)
+        if columns != ["table", "column", "type"]:
+            raise ValueError(f"unexpected Timestream schema columns: {columns!r}")
+        return [
+            {"table": str(table), "column": str(column), "type": str(type_)}
+            for table, column, type_ in rows
+        ]
+
+    def close(self) -> None:
+        if self._close_client:
+            self._client.close()

--- a/tests/db/test_connectorx_connection.py
+++ b/tests/db/test_connectorx_connection.py
@@ -1,0 +1,40 @@
+"""Tests for the ConnectorX adapter without installing ConnectorX."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db.connectorx import ConnectorXConnection
+
+
+def test_connectorx_infers_dialect_and_forwards_options(monkeypatch):
+    calls = []
+
+    def read_sql(connection, query, **options):
+        calls.append((connection, query, options))
+        return (["x"], [[1]])
+
+    monkeypatch.setitem(sys.modules, "connectorx", SimpleNamespace(read_sql=read_sql))
+    monkeypatch.setitem(sys.modules, "polars", SimpleNamespace())
+    connection = ConnectorXConnection(
+        "postgresql://localhost/db", return_type="polars", protocol="binary"
+    )
+
+    assert connection.dialect == "postgres"
+    assert connection.cursor().execute("select 1").fetchall() == [[1]]
+    assert calls == [
+        (
+            "postgresql://localhost/db",
+            "select 1",
+            {"return_type": "polars", "protocol": "binary"},
+        )
+    ]
+
+
+def test_connectorx_federated_requires_dialect(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules, "connectorx", SimpleNamespace(read_sql=lambda: None)
+    )
+    with pytest.raises(ValueError, match="dialect is required"):
+        ConnectorXConnection({"one": "postgresql://localhost/one"})

--- a/tests/db/test_cursor.py
+++ b/tests/db/test_cursor.py
@@ -127,13 +127,18 @@ def test_parameters_none_or_empty_ok(five_rows):
     cur.execute("SELECT 1", parameters=[])  # empty is falsy -> allowed
 
 
-def test_connection_is_abstract():
-    # A subclass missing a hook can't be instantiated (Connection is an ABC).
+def test_connection_requires_fetch_but_schema_is_optional():
     class Incomplete(Connection):
         dialect = "fake"
 
-        def _fetch(self, query):  # schema_rows still missing
-            return ([], [], None)
-
     with pytest.raises(TypeError):
         Incomplete()
+
+    class Complete(Connection):
+        dialect = "fake"
+
+        def _fetch(self, query):
+            return ([], [], None)
+
+    connection = Complete()
+    assert connection.schema_rows() == []

--- a/tests/db/test_d1_connection.py
+++ b/tests/db/test_d1_connection.py
@@ -1,0 +1,44 @@
+"""Tests for the Cloudflare D1 REST connection."""
+
+import responses
+
+from moutils.db.d1 import D1Connection
+
+_URL = "https://api.cloudflare.com/client/v4/accounts/acct/d1/database/db/raw"
+
+
+def _response(columns, rows):
+    return {
+        "success": True,
+        "result": [{"success": True, "results": {"columns": columns, "rows": rows}}],
+    }
+
+
+@responses.activate
+def test_d1_query_and_auth():
+    responses.post(_URL, json=_response(["name", "n"], [["Ada", 1]]))
+    connection = D1Connection("acct", "db", "token")
+
+    cursor = connection.cursor().execute("select name, n from people")
+
+    assert cursor.fetchall() == [["Ada", 1]]
+    request = responses.calls[0].request
+    assert request.headers["Authorization"] == "Bearer token"
+    assert request.body == b'{"sql": "select name, n from people"}'
+    connection.close()
+
+
+@responses.activate
+def test_d1_schema_rows():
+    responses.post(
+        _URL,
+        json=_response(
+            ["table", "column", "type"],
+            [["people", "name", "TEXT"], ["people", "age", "INTEGER"]],
+        ),
+    )
+    connection = D1Connection("acct", "db", "token")
+    assert connection.schema_rows() == [
+        {"table": "people", "column": "name", "type": "TEXT"},
+        {"table": "people", "column": "age", "type": "INTEGER"},
+    ]

--- a/tests/db/test_dependencies.py
+++ b/tests/db/test_dependencies.py
@@ -1,0 +1,58 @@
+"""Tests for optional database dependency validation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db._dependencies import require_dependency
+
+
+def test_require_dependency_has_actionable_error(monkeypatch):
+    def missing(_module_name):
+        raise ModuleNotFoundError(name="client_module")
+
+    monkeypatch.setattr("moutils.db._dependencies.import_module", missing)
+
+    with pytest.raises(
+        ImportError,
+        match=r"ExampleConnection requires `client-package`.*pip install client-package",
+    ):
+        require_dependency(
+            "client_module",
+            connection_name="ExampleConnection",
+            package_name="client-package",
+        )
+
+
+def test_require_dependency_does_not_cache_missing_package(monkeypatch):
+    calls = []
+    installed = SimpleNamespace()
+
+    def install_between_calls(module_name):
+        calls.append(module_name)
+        if len(calls) == 1:
+            raise ModuleNotFoundError(name=module_name)
+        return installed
+
+    monkeypatch.setattr("moutils.db._dependencies.import_module", install_between_calls)
+
+    with pytest.raises(ImportError):
+        require_dependency("client_module", connection_name="ExampleConnection")
+
+    assert (
+        require_dependency("client_module", connection_name="ExampleConnection")
+        is installed
+    )
+    assert calls == ["client_module", "client_module"]
+
+
+def test_require_dependency_preserves_transitive_import_error(monkeypatch):
+    def broken_dependency(_module_name):
+        raise ModuleNotFoundError(name="transitive_dependency")
+
+    monkeypatch.setattr("moutils.db._dependencies.import_module", broken_dependency)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        require_dependency("client_module", connection_name="ExampleConnection")
+
+    assert exc_info.value.name == "transitive_dependency"

--- a/tests/db/test_dune_connection.py
+++ b/tests/db/test_dune_connection.py
@@ -1,0 +1,72 @@
+"""Tests for the Dune raw SQL adapter."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db.dune import DuneConnection
+
+
+@pytest.fixture(autouse=True)
+def _dune_client_installed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "dune_client", SimpleNamespace())
+
+
+def _result(rows, next_offset=None):
+    metadata = SimpleNamespace(column_names=["name"], column_types=["varchar"])
+    return SimpleNamespace(
+        result=SimpleNamespace(rows=rows, metadata=metadata),
+        next_offset=next_offset,
+    )
+
+
+class FakeDune:
+    def __init__(self, states, results):
+        self.states = iter(states)
+        self.results = iter(results)
+        self.execute_calls = []
+        self.result_calls = []
+
+    def execute_sql(self, **kwargs):
+        self.execute_calls.append(kwargs)
+        return SimpleNamespace(execution_id="job")
+
+    def get_execution_status(self, execution_id):
+        state = next(self.states)
+        return SimpleNamespace(state=SimpleNamespace(value=state), error=None)
+
+    def get_execution_results(self, execution_id, **kwargs):
+        self.result_calls.append((execution_id, kwargs))
+        return next(self.results)
+
+
+def test_dune_waits_and_paginates():
+    client = FakeDune(
+        ["QUERY_STATE_EXECUTING", "QUERY_STATE_COMPLETED"],
+        [_result([{"name": "Ada"}], 1), _result([{"name": "Grace"}])],
+    )
+    connection = DuneConnection(
+        client,
+        performance="medium",
+        poll_interval=0,
+        batch_size=1,
+    )
+
+    cursor = connection.cursor().execute("select name from people")
+
+    assert cursor.fetchall() == [["Ada"], ["Grace"]]
+    assert cursor.description[0][1] == "varchar"
+    assert client.execute_calls == [
+        {"query_sql": "select name from people", "performance": "medium"}
+    ]
+    assert client.result_calls == [
+        ("job", {"limit": 1, "offset": 0}),
+        ("job", {"limit": 1, "offset": 1}),
+    ]
+
+
+def test_dune_failure_raises():
+    client = FakeDune(["QUERY_STATE_FAILED"], [])
+    with pytest.raises(RuntimeError, match="QUERY_STATE_FAILED"):
+        DuneConnection(client, poll_interval=0).cursor().execute("select 1")

--- a/tests/db/test_elasticsearch_connection.py
+++ b/tests/db/test_elasticsearch_connection.py
@@ -1,0 +1,67 @@
+"""Tests for the Elasticsearch SQL adapter."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db.elasticsearch import ElasticsearchConnection
+
+
+@pytest.fixture(autouse=True)
+def _elasticsearch_installed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "elasticsearch", SimpleNamespace())
+
+
+class FakeSQL:
+    def __init__(self, pages):
+        self.pages = iter(pages)
+        self.queries = []
+        self.cleared = []
+
+    def query(self, **kwargs):
+        self.queries.append(kwargs)
+        return SimpleNamespace(body=next(self.pages))
+
+    def clear_cursor(self, *, cursor):
+        self.cleared.append(cursor)
+
+
+def test_elasticsearch_paginates():
+    sql = FakeSQL(
+        [
+            {
+                "columns": [{"name": "name", "type": "keyword"}],
+                "rows": [["Ada"]],
+                "cursor": "next",
+            },
+            {"rows": [["Grace"]]},
+        ]
+    )
+    connection = ElasticsearchConnection(SimpleNamespace(sql=sql), fetch_size=10)
+
+    cursor = connection.cursor().execute("select name from people")
+
+    assert cursor.fetchall() == [["Ada"], ["Grace"]]
+    assert cursor.description[0][1] == "keyword"
+    assert sql.queries == [
+        {"query": "select name from people", "fetch_size": 10},
+        {"cursor": "next"},
+    ]
+    assert sql.cleared == []
+
+
+def test_elasticsearch_clears_cursor_after_error():
+    sql = FakeSQL(
+        [
+            {
+                "columns": [{"name": "name", "type": "keyword"}],
+                "rows": [],
+                "cursor": "next",
+            },
+            {"rows": "bad"},
+        ]
+    )
+    with pytest.raises(ValueError, match="rows"):
+        ElasticsearchConnection(SimpleNamespace(sql=sql)).cursor().execute("select 1")
+    assert sql.cleared == ["next"]

--- a/tests/db/test_opensearch_connection.py
+++ b/tests/db/test_opensearch_connection.py
@@ -1,0 +1,52 @@
+"""Tests for the OpenSearch SQL adapter."""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db.opensearch import OpenSearchConnection
+
+
+@pytest.fixture(autouse=True)
+def _opensearch_installed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "opensearchpy", SimpleNamespace())
+
+
+class FakeTransport:
+    def __init__(self, pages):
+        self.pages = iter(pages)
+        self.calls = []
+
+    def perform_request(self, method, path, *, body):
+        self.calls.append((method, path, body))
+        return next(self.pages)
+
+
+def test_opensearch_paginates_jdbc_results():
+    transport = FakeTransport(
+        [
+            {
+                "schema": [{"name": "name", "type": "keyword"}],
+                "datarows": [["Ada"]],
+                "cursor": "next",
+            },
+            {"datarows": [["Grace"]]},
+        ]
+    )
+    connection = OpenSearchConnection(
+        SimpleNamespace(transport=transport), fetch_size=5
+    )
+
+    cursor = connection.cursor().execute("select name from people")
+
+    assert cursor.fetchall() == [["Ada"], ["Grace"]]
+    assert cursor.description[0][1] == "keyword"
+    assert transport.calls == [
+        (
+            "POST",
+            "/_plugins/_sql",
+            {"query": "select name from people", "fetch_size": 5},
+        ),
+        ("POST", "/_plugins/_sql", {"cursor": "next"}),
+    ]

--- a/tests/db/test_query_connection.py
+++ b/tests/db/test_query_connection.py
@@ -1,0 +1,66 @@
+"""Tests for the generic query callable adapter."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db.query import QueryConnection, QueryResult, normalize_result
+
+
+def test_query_result_tuple_executes():
+    connection = QueryConnection(
+        lambda sql: (["value"], [[sql]], ["text"]), dialect="sqlite"
+    )
+
+    cursor = connection.cursor().execute("select 1")
+
+    assert connection.dialect == "sqlite"
+    assert cursor.fetchall() == [["select 1"]]
+    assert cursor.description[0][1] == "text"
+
+
+def test_record_mappings_preserve_first_record_order():
+    result = normalize_result([{"b": 2, "a": 1}, {"b": 4, "a": 3}])
+
+    assert list(result.columns) == ["b", "a"]
+    assert list(result.rows) == [[2, 1], [4, 3]]
+
+
+def test_mapping_result():
+    result = normalize_result({"columns": ["x"], "rows": [[1]], "types": ["int"]})
+    assert result == QueryResult(["x"], [[1]], ["int"])
+
+
+def test_polars_like_result():
+    frame = SimpleNamespace(columns=["x"], dtypes=["Int64"], rows=lambda: [(1,)])
+    result = normalize_result(frame)
+    assert list(result.rows) == [(1,)]
+    assert result.types == ["Int64"]
+
+
+def test_arrow_like_result():
+    frame = SimpleNamespace(
+        column_names=["x"],
+        schema=SimpleNamespace(types=["int64"]),
+        to_pylist=lambda: [{"x": 1}],
+    )
+    result = normalize_result(frame)
+    assert list(result.rows) == [[1]]
+    assert result.types == ["int64"]
+
+
+def test_schema_and_close_callbacks():
+    closed = []
+    connection = QueryConnection(
+        lambda sql: ([], []),
+        schema=lambda: [{"table": "t", "column": "x", "type": "int"}],
+        close=lambda: closed.append(True),
+    )
+    assert connection.schema_rows()[0]["table"] == "t"
+    connection.close()
+    assert closed == [True]
+
+
+def test_invalid_result_raises():
+    with pytest.raises(TypeError, match="unsupported query result"):
+        normalize_result(42)

--- a/tests/db/test_timestream_connection.py
+++ b/tests/db/test_timestream_connection.py
@@ -1,0 +1,85 @@
+"""Tests for the Amazon Timestream query adapter."""
+
+import sys
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from moutils.db.timestream import TimestreamConnection
+
+
+@pytest.fixture(autouse=True)
+def _boto3_installed(monkeypatch):
+    monkeypatch.setitem(sys.modules, "boto3", SimpleNamespace())
+
+
+class FakeTimestream:
+    def __init__(self, pages):
+        self.pages = iter(pages)
+        self.calls = []
+
+    def query(self, **kwargs):
+        self.calls.append(kwargs)
+        return next(self.pages)
+
+
+def test_timestream_paginates_and_decodes_values():
+    columns = [
+        {"Name": "n", "Type": {"ScalarType": "BIGINT"}},
+        {"Name": "ratio", "Type": {"ScalarType": "DECIMAL"}},
+        {
+            "Name": "tags",
+            "Type": {"ArrayColumnInfo": {"Type": {"ScalarType": "VARCHAR"}}},
+        },
+    ]
+    client = FakeTimestream(
+        [
+            {
+                "ColumnInfo": columns,
+                "Rows": [
+                    {
+                        "Data": [
+                            {"ScalarValue": "2"},
+                            {"ScalarValue": "1.25"},
+                            {"ArrayValue": [{"ScalarValue": "a"}]},
+                        ]
+                    }
+                ],
+                "NextToken": "next",
+            },
+            {
+                "ColumnInfo": columns,
+                "Rows": [
+                    {
+                        "Data": [
+                            {"ScalarValue": "3"},
+                            {"NullValue": True},
+                            {"ArrayValue": []},
+                        ]
+                    }
+                ],
+            },
+        ]
+    )
+    connection = TimestreamConnection(client, page_size=25)
+
+    cursor = connection.cursor().execute("select * from metrics")
+
+    assert cursor.fetchall() == [
+        [2, Decimal("1.25"), ["a"]],
+        [3, None, []],
+    ]
+    assert [column[1] for column in cursor.description] == [
+        "BIGINT",
+        "DECIMAL",
+        "ARRAY<VARCHAR>",
+    ]
+    assert client.calls == [
+        {"QueryString": "select * from metrics", "MaxRows": 25},
+        {
+            "QueryString": "select * from metrics",
+            "MaxRows": 25,
+            "NextToken": "next",
+        },
+    ]


### PR DESCRIPTION
Adds connection wrappers for non-DBAPI data sources to `moutils.db`:

- **connectorx** – fast query engine returning DataFrames
- **d1** – Cloudflare D1 (HTTP API)
- **dune** – Dune Analytics queries
- **elasticsearch** / **opensearch** – search clusters
- **query** – generic HTTP query wrapper
- **timestream** – AWS Timestream

Also adds a `_dependencies` helper for optional-import handling, and updates `_core`, the package `__init__`, README, and tests.

All 88 db tests pass; ruff format + check clean.