### PR TITLE
fix(db): harden query result handling

### DIFF
--- a/src/moutils/db/connectorx.py
+++ b/src/moutils/db/connectorx.py
@@ -62,11 +62,20 @@ class ConnectorXConnection(QueryConnection):
             )
 
         def query(sql: str) -> Any:
-            return connectorx.read_sql(
+            result = connectorx.read_sql(
                 connection,
                 sql,
                 return_type=return_type,
                 **read_sql_options,
             )
+            if return_type == "arrow_stream":
+                read_all = getattr(result, "read_all", None)
+                if not callable(read_all):
+                    raise TypeError(
+                        "ConnectorX return_type='arrow_stream' did not return "
+                        "a PyArrow RecordBatchReader"
+                    )
+                return read_all()
+            return result
 
         super().__init__(query, dialect=resolved_dialect, schema=schema)

--- a/src/moutils/db/query.py
+++ b/src/moutils/db/query.py
@@ -21,7 +21,13 @@ class QueryResult:
 def _records_result(records: list[Mapping[Any, Any]]) -> QueryResult:
     if not records:
         return QueryResult([], [])
-    columns = list(records[0])
+    columns: list[Any] = []
+    seen: set[Any] = set()
+    for record in records:
+        for column in record:
+            if column not in seen:
+                seen.add(column)
+                columns.append(column)
     return QueryResult(
         columns, ([record.get(column) for column in columns] for record in records)
     )

--- a/tests/db/test_connectorx_connection.py
+++ b/tests/db/test_connectorx_connection.py
@@ -32,6 +32,29 @@ def test_connectorx_infers_dialect_and_forwards_options(monkeypatch):
     ]
 
 
+def test_connectorx_arrow_stream_reads_table(monkeypatch):
+    table = SimpleNamespace(
+        column_names=["x"],
+        schema=SimpleNamespace(types=["int64"]),
+        to_pylist=lambda: [{"x": 1}],
+    )
+    reader = SimpleNamespace(read_all=lambda: table)
+    monkeypatch.setitem(
+        sys.modules,
+        "connectorx",
+        SimpleNamespace(read_sql=lambda *args, **kwargs: reader),
+    )
+    monkeypatch.setitem(sys.modules, "pyarrow", SimpleNamespace())
+
+    connection = ConnectorXConnection(
+        "sqlite:///tmp/data.db", return_type="arrow_stream"
+    )
+
+    cursor = connection.cursor().execute("select 1")
+    assert cursor.fetchall() == [[1]]
+    assert cursor.description[0][1] == "int64"
+
+
 def test_connectorx_federated_requires_dialect(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "connectorx", SimpleNamespace(read_sql=lambda: None)

--- a/tests/db/test_opensearch_connection.py
+++ b/tests/db/test_opensearch_connection.py
@@ -50,3 +50,28 @@ def test_opensearch_paginates_jdbc_results():
         ),
         ("POST", "/_plugins/_sql", {"cursor": "next"}),
     ]
+
+
+def test_opensearch_closes_cursor_after_error():
+    transport = FakeTransport(
+        [
+            {
+                "schema": [{"name": "name", "type": "keyword"}],
+                "datarows": [],
+                "cursor": "next",
+            },
+            {"datarows": "bad"},
+            {},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="rows"):
+        OpenSearchConnection(SimpleNamespace(transport=transport)).cursor().execute(
+            "select 1"
+        )
+
+    assert transport.calls[-1] == (
+        "POST",
+        "/_plugins/_sql/close",
+        {"cursor": "next"},
+    )

--- a/tests/db/test_query_connection.py
+++ b/tests/db/test_query_connection.py
@@ -26,6 +26,13 @@ def test_record_mappings_preserve_first_record_order():
     assert list(result.rows) == [[2, 1], [4, 3]]
 
 
+def test_record_mappings_include_fields_from_later_records():
+    result = normalize_result([{"a": 1}, {"b": 2, "a": 3}, {"c": 4}])
+
+    assert list(result.columns) == ["a", "b", "c"]
+    assert list(result.rows) == [[1, None, None], [3, 2, None], [None, None, 4]]
+
+
 def test_mapping_result():
     result = normalize_result({"columns": ["x"], "rows": [[1]], "types": ["int"]})
     assert result == QueryResult(["x"], [[1]], ["int"])


### PR DESCRIPTION
## Summary
- `ConnectorXConnection` now materializes `return_type="arrow_stream"` results via `read_all()`, with a clear error if ConnectorX returns something other than a PyArrow `RecordBatchReader`.
- `_records_result` collects columns across **all** records (not just the first), so fields appearing only in later records are no longer dropped.

## Tests
- Added coverage for arrow_stream reading, record columns from later records, and OpenSearch cursor cleanup after an error.
- `uv run pytest tests/db/` → 91 passed.