### PR TITLE
feat: add an ONNX adapter for WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,77 @@ These connections do not support bound parameters. Use static or trusted SQL.
 Do not insert untrusted values into SQL strings. Provider adapters that receive
 an existing client leave that client open by default.
 
+## ONNX runtime caching
+
+`moutils.onnx.OnnxRuntime` wraps a serialized ONNX model in a lazy inference
+session and registers a marimo cache stub for it. When marimo caches an
+`OnnxRuntime`, it stores exactly the model bytes, not the training framework's
+objects.
+
+This lets a WASM export ship a trained model and run inference in the browser
+without the training framework. Enable cell caching in the notebook header. Then
+build the runtime in a cell:
+
+```python
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "numpy",
+#     "moutils",
+#     # Training-only: the browser uses onnxruntime-web, so exclude these under
+#     # Pyodide (emscripten). onnxruntime has no pure-Python wheel either.
+#     "torch; sys_platform != 'emscripten'",
+#     "onnx; sys_platform != 'emscripten'",
+#     "onnxruntime; sys_platform != 'emscripten'",
+# ]
+#
+# [tool.marimo.runtime]
+# cache_cells = true
+# ///
+
+import io
+from moutils.onnx import OnnxRuntime
+
+
+def _make_runtime():
+    # torch and every torch object stay local to this function, so they never
+    # become cached cell defs. Only the returned runtime does.
+    import torch
+
+    model = torch.nn.Linear(4, 2)
+    buf = io.BytesIO()
+    torch.onnx.export(model, (torch.zeros(1, 4),), buf,
+                      input_names=["x"], output_names=["logits"], dynamo=False)
+    return OnnxRuntime(buf.getvalue())
+
+
+runtime = _make_runtime()  # cached as its ONNX bytes, via the stub
+```
+
+Export the notebook with `marimo export html-wasm notebook.py -o dist
+--execute`. The `--execute` flag runs the notebook once, and `cache_cells`
+bundles the cell cache into `dist`. Serving `dist` restores `runtime` from its
+ONNX bytes and runs inference against `onnxruntime-web` in the browser. The page
+never imports torch, and Pyodide never installs it.
+
+Mark the training packages as native-only, as the header above does. The browser
+runs `onnxruntime-web` from a CDN, so Pyodide never installs the Python
+`onnxruntime` package. That package has no pure-Python wheel and fails to install
+under Pyodide.
+
+Keep torch out of the cell's top-level names. A bare `import torch`, or a
+torch-typed variable such as a model or a tensor, becomes a cached cell def.
+Restoring that def then needs torch. The helper above keeps them function-local.
+
+For inference outside the browser, install the `wasm` extra:
+`pip install "moutils[wasm]"`. It adds `onnxruntime`. In the browser,
+`onnxruntime-web` loads from a CDN, so no extra is needed.
+
+See [`notebooks/onnx_mnist1d.py`](notebooks/onnx_mnist1d.py) for a full example:
+an MLP trained on MNIST-1D, exported to a static page where inference runs live
+from a lasso selection.
+
 ## Development
 
 We use [uv](https://github.com/astral-sh/uv) for development.

--- a/README.md
+++ b/README.md
@@ -500,10 +500,11 @@ row = np.zeros((1, 4), dtype=np.float32)
 logits = (await runtime.run({"x": row}, ["logits"]))[0]
 ```
 
-Export the notebook with `marimo export html-wasm notebook.py -o dist
---execute`. The `--execute` flag runs the notebook once, and `cache_cells`
-bundles the cell cache into `dist`. Serving `dist` restores `runtime` from its
-ONNX bytes and runs inference against `onnxruntime-web` in the browser.
+Export the notebook with
+`marimo export html-wasm notebook.py -o dist --execute`. The `--execute` flag
+runs the notebook once, and `cache_cells` bundles the cell cache into `dist`.
+Serving `dist` restores `runtime` from its ONNX bytes and runs inference against
+`onnxruntime-web` in the browser.
 
 Mark the training packages as native-only, as the header above does.
 For inference outside the browser, install the `wasm` extra:

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ These connections do not support bound parameters. Use static or trusted SQL.
 Do not insert untrusted values into SQL strings. Provider adapters that receive
 an existing client leave that client open by default.
 
-## ONNX runtime caching
+## ONNX runtime adapter
 
 `moutils.onnx.OnnxRuntime` wraps a serialized ONNX model in a lazy inference
 session and registers a marimo cache stub for it. When marimo caches an
@@ -475,7 +475,7 @@ build the runtime in a cell:
 # cache_cells = true
 # ///
 
-import io
+import numpy as np
 from moutils.onnx import OnnxRuntime
 
 
@@ -485,33 +485,30 @@ def _make_runtime():
     import torch
 
     model = torch.nn.Linear(4, 2)
-    buf = io.BytesIO()
-    torch.onnx.export(model, (torch.zeros(1, 4),), buf,
-                      input_names=["x"], output_names=["logits"], dynamo=False)
-    return OnnxRuntime(buf.getvalue())
+    # Also supports OnnxRuntime.from_jax !
+    return OnnxRuntime.from_torch(
+        model, (torch.zeros(1, 4),),
+        input_names=["x"], output_names=["logits"], dynamo=False,
+    )
 
 
 runtime = _make_runtime()  # cached as its ONNX bytes, via the stub
+
+# Run inference! Inputs go in by name, and the requested outputs come back in
+# order.
+row = np.zeros((1, 4), dtype=np.float32)
+logits = (await runtime.run({"x": row}, ["logits"]))[0]
 ```
 
 Export the notebook with `marimo export html-wasm notebook.py -o dist
 --execute`. The `--execute` flag runs the notebook once, and `cache_cells`
 bundles the cell cache into `dist`. Serving `dist` restores `runtime` from its
-ONNX bytes and runs inference against `onnxruntime-web` in the browser. The page
-never imports torch, and Pyodide never installs it.
+ONNX bytes and runs inference against `onnxruntime-web` in the browser.
 
-Mark the training packages as native-only, as the header above does. The browser
-runs `onnxruntime-web` from a CDN, so Pyodide never installs the Python
-`onnxruntime` package. That package has no pure-Python wheel and fails to install
-under Pyodide.
-
-Keep torch out of the cell's top-level names. A bare `import torch`, or a
-torch-typed variable such as a model or a tensor, becomes a cached cell def.
-Restoring that def then needs torch. The helper above keeps them function-local.
-
+Mark the training packages as native-only, as the header above does.
 For inference outside the browser, install the `wasm` extra:
 `pip install "moutils[wasm]"`. It adds `onnxruntime`. In the browser,
-`onnxruntime-web` loads from a CDN, so no extra is needed.
+`onnxruntime-web` loads from a CDN, so no extra packages are needed.
 
 See [`notebooks/onnx_mnist1d.py`](notebooks/onnx_mnist1d.py) for a full example:
 an MLP trained on MNIST-1D, exported to a static page where inference runs live

--- a/README.md
+++ b/README.md
@@ -448,14 +448,18 @@ an existing client leave that client open by default.
 
 ## ONNX runtime adapter
 
-`moutils.onnx.OnnxRuntime` wraps a serialized ONNX model in a lazy inference
-session and registers a marimo cache stub for it. When marimo caches an
-`OnnxRuntime`, it stores exactly the model bytes, not the training framework's
-objects.
+`moutils.onnx.OnnxRuntime` exposes a inference runtime for pytorch and jax
+models in WASM marimo notebooks through a
+[cacheable](https://docs.marimo.io/api/caching/) interface and the
+[ONNX runtime](https://onnxruntime.ai/). As jax and torch are not available in
+the browser, the adapter
+exports the model to ONNX and runs inference with `onnxruntime-web` when used in
+browser. See [`notebooks/onnx_mnist1d.py`](notebooks/onnx_mnist1d.py) for a
+full example- which trains a MNIST-1D model, then bundles a static page, and
+provides interactive inference.
 
-This lets a WASM export ship a trained model and run inference in the browser
-without the training framework. Enable cell caching in the notebook header. Then
-build the runtime in a cell:
+To use this export ability, enable cell caching in the notebook header (or
+`pyproject.toml`). Then build the runtime in a cell:
 
 ```python
 # /// script
@@ -480,8 +484,8 @@ from moutils.onnx import OnnxRuntime
 
 
 def _make_runtime():
-    # torch and every torch object stay local to this function, so they never
-    # become cached cell defs. Only the returned runtime does.
+    # torch normally load in browser. cached cell's lazy evaluation
+    # means this browser execution won't ever attempt to load the module.
     import torch
 
     model = torch.nn.Linear(4, 2)
@@ -492,7 +496,7 @@ def _make_runtime():
     )
 
 
-runtime = _make_runtime()  # cached as its ONNX bytes, via the stub
+runtime = _make_runtime()  # cached as its ONNX bytes
 
 # Run inference! Inputs go in by name, and the requested outputs come back in
 # order.
@@ -500,20 +504,15 @@ row = np.zeros((1, 4), dtype=np.float32)
 logits = (await runtime.run({"x": row}, ["logits"]))[0]
 ```
 
-Export the notebook with
-`marimo export html-wasm notebook.py -o dist --execute`. The `--execute` flag
-runs the notebook once, and `cache_cells` bundles the cell cache into `dist`.
-Serving `dist` restores `runtime` from its ONNX bytes and runs inference against
-`onnxruntime-web` in the browser.
+Export the notebook with `marimo export html-wasm notebook.py -o dist
+--execute`. The `--execute` flag runs the notebook once, and `cache_cells`
+bundles the cell cache into `dist`. Serving `dist` restores `runtime` from its
+ONNX bytes and runs inference against `onnxruntime-web` in the browser.
 
 Mark the training packages as native-only, as the header above does.
 For inference outside the browser, install the `wasm` extra:
 `pip install "moutils[wasm]"`. It adds `onnxruntime`. In the browser,
 `onnxruntime-web` loads from a CDN, so no extra packages are needed.
-
-See [`notebooks/onnx_mnist1d.py`](notebooks/onnx_mnist1d.py) for a full example:
-an MLP trained on MNIST-1D, exported to a static page where inference runs live
-from a lasso selection.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -484,8 +484,8 @@ from moutils.onnx import OnnxRuntime
 
 
 def _make_runtime():
-    # torch normally load in browser. cached cell's lazy evaluation
-    # means this browser execution won't ever attempt to load the module.
+    # torch normally doesn't load in the browser; the cached cell's lazy
+    # evaluation means this browser execution never attempts to load the module.
     import torch
 
     model = torch.nn.Linear(4, 2)

--- a/README.md
+++ b/README.md
@@ -448,15 +448,15 @@ an existing client leave that client open by default.
 
 ## ONNX runtime adapter
 
-`moutils.onnx.OnnxRuntime` exposes a inference runtime for pytorch and jax
+`moutils.onnx.OnnxRuntime` exposes an inference runtime for PyTorch and JAX
 models in WASM marimo notebooks through a
 [cacheable](https://docs.marimo.io/api/caching/) interface and the
-[ONNX runtime](https://onnxruntime.ai/). As jax and torch are not available in
-the browser, the adapter
-exports the model to ONNX and runs inference with `onnxruntime-web` when used in
-browser. See [`notebooks/onnx_mnist1d.py`](notebooks/onnx_mnist1d.py) for a
-full example- which trains a MNIST-1D model, then bundles a static page, and
-provides interactive inference.
+[ONNX runtime](https://onnxruntime.ai/). Since PyTorch and JAX aren't available
+in the browser, the adapter exports the model to ONNX and runs inference with
+`onnxruntime-web` when used in the browser. See
+[`notebooks/onnx_mnist1d.py`](notebooks/onnx_mnist1d.py) for a full example,
+which trains an MNIST-1D model, bundles a static page, and provides interactive
+inference.
 
 To use this export ability, enable cell caching in the notebook header (or
 `pyproject.toml`). Then build the runtime in a cell:

--- a/notebooks/onnx_mnist1d.py
+++ b/notebooks/onnx_mnist1d.py
@@ -1,0 +1,317 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "numpy",
+#     "matplotlib",
+#     "moutils",
+#     "mnist1d; sys_platform != 'emscripten'",
+#     "pymde; sys_platform != 'emscripten'",
+#     "torch; sys_platform != 'emscripten'",
+#     "onnx; sys_platform != 'emscripten'",
+#     "onnxruntime; sys_platform != 'emscripten'",
+# ]
+#
+# [tool.uv.sources.torch]
+# index = "pytorch-cpu"
+#
+# [[tool.uv.index]]
+# name = "pytorch-cpu"
+# url = "https://download.pytorch.org/whl/cpu"
+# explicit = true
+#
+# [tool.marimo.runtime]
+# cache_cells = true
+#
+# [tool.marimo.export]
+# lock_kind = "observed"
+# ///
+"""Cache a live ONNX runtime object and restore it without the training framework.
+
+A `_train()` helper trains an MLP on MNIST-1D and computes a PyMDE embedding.
+Cell caching bundles its torch-free results into the export, and moutils' cache
+stub stores the `OnnxRuntime` as exactly its ONNX bytes. On a cache hit (the
+exported page) marimo skips `_train()` — torch / pymde / mnist1d never import —
+yet `runtime` restores as a working inference session. Lasso a region in the
+embedding and inference runs through it: native `onnxruntime` on a host,
+`onnxruntime-web` in the browser via WASM.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+with app.setup(hide_code=True):
+    import time
+
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from moutils.onnx import OnnxRuntime
+
+
+@app.cell(hide_code=True)
+def intro():
+    mo.md(r"""
+    # A live ONNX runtime, restored straight from the cache
+
+    An MLP trained on MNIST-1D and a PyMDE embedding of the held-out set. The
+    training runs in a cached `_train()` helper that returns a
+    `moutils.onnx.OnnxRuntime`. Moutils' cache stub serializes that runtime as
+    exactly its ONNX bytes. On a cache hit, torch / pymde / mnist1d never import,
+    yet `runtime` restores as a working session.
+
+    Lasso a region below, then toggle through the selected samples: each runs
+    through the restored runtime — `onnxruntime-web` in the browser — and the
+    confusion matrix summarizes the region from cached predictions.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def train():
+    def _train():
+        # torch / pymde / mnist1d import here, so they stay local to this
+        # function and never become cached cell defs. Only the torch-free
+        # results returned below are cached, and cell caching bundles them
+        # into the export.
+        import io
+
+        import pymde
+        import torch
+        from mnist1d.data import get_dataset_args, make_dataset
+
+        args = get_dataset_args()
+        args.num_samples = 10000  # 80/20 -> 8000 train / 2000 test
+        data = make_dataset(args)
+        x_train = torch.tensor(data["x"], dtype=torch.float32)
+        y_train = torch.tensor(data["y"])
+        x_test_np = data["x_test"].astype("float32")
+        y_test = data["y_test"].astype(int)
+
+        model = torch.nn.Sequential(
+            torch.nn.Linear(40, 256),
+            torch.nn.ReLU(),
+            torch.nn.Linear(256, 100),
+            torch.nn.ReLU(),
+            torch.nn.Linear(100, 10),
+        )
+        opt = torch.optim.Adam(model.parameters(), lr=3e-3)
+        loss_fn = torch.nn.CrossEntropyLoss()
+        for _ in range(400):
+            opt.zero_grad()
+            loss_fn(model(x_train), y_train).backward()
+            opt.step()
+
+        model.eval()
+        with torch.no_grad():
+            test_logits = model(torch.tensor(x_test_np))
+        test_pred = test_logits.argmax(1).numpy()
+        acc = float((test_pred == y_test).mean())
+
+        buf = io.BytesIO()
+        torch.onnx.export(
+            model,
+            (torch.zeros(1, 40),),
+            buf,
+            input_names=["x"],
+            output_names=["logits"],
+            dynamic_axes={"x": {0: "n"}, "logits": {0: "n"}},
+            dynamo=False,
+        )
+        runtime = OnnxRuntime(buf.getvalue())
+
+        mde = pymde.preserve_neighbors(
+            torch.tensor(x_test_np),
+            embedding_dim=2,
+            constraint=pymde.Standardized(),
+            repulsive_fraction=1.5,
+            verbose=False,
+        )
+        embedding_2d = mde.embed(verbose=False).cpu().numpy()
+        return acc, embedding_2d, runtime, test_pred, x_test_np, y_test
+
+    acc, embedding_2d, runtime, test_pred, x_test_np, y_test = _train()
+    trained_at = time.time()
+    return acc, embedding_2d, runtime, test_pred, trained_at, x_test_np, y_test
+
+
+@app.cell(hide_code=True)
+def status(acc, trained_at):
+    _age_min = (time.time() - trained_at) / 60
+    mo.md(
+        f"""
+        {
+            "⚡ **Restored from the cache** — this MLP was trained "
+            f"{_age_min:,.0f} minutes ago. The OnnxRuntime and PyMDE embedding "
+            "bound here without re-running a step."
+            if _age_min > 1
+            else "🔥 **Cold run** — the export will carry these results as cache blobs."
+        }
+        Held-out accuracy **{acc:.1%}** · 400 Adam steps · 40→256→100→10 MLP
+        """
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def embedding_plot(embedding_2d, y_test):
+    _fig, _ax = plt.subplots(figsize=(6, 5))
+    _sc = _ax.scatter(
+        embedding_2d[:, 0],
+        embedding_2d[:, 1],
+        c=y_test,
+        cmap="tab10",
+        s=10,
+        alpha=0.6,
+    )
+    _ax.set_title("MNIST-1D held-out embedding (PyMDE) — lasso to pick a sample")
+    _ax.set_axis_off()
+    _fig.colorbar(_sc, ax=_ax, ticks=np.arange(10), shrink=0.8)
+    _fig.tight_layout()
+    embed_plot = mo.ui.matplotlib(_ax)
+    embed_plot
+    return (embed_plot,)
+
+
+@app.cell(hide_code=True)
+def select(embed_plot, embedding_2d):
+    # Which held-out samples fall inside the lasso.
+    _mask = embed_plot.value.get_mask(embedding_2d[:, 0], embedding_2d[:, 1])
+    sel = np.nonzero(_mask)[0]
+    return (sel,)
+
+
+@app.cell(hide_code=True)
+def toggle(sel):
+    mo.stop(
+        len(sel) == 0,
+        mo.md(
+            "*Lasso-select a region in the embedding above to run samples "
+            "through the model.*"
+        ),
+    )
+    pick = (
+        mo.ui.slider(
+            0,
+            len(sel) - 1,
+            value=0,
+            full_width=True,
+            label=f"sample within selection ({len(sel)} selected)",
+        )
+        if len(sel) > 1
+        else None
+    )
+    pick if pick is not None else mo.md("**1 sample selected.**")
+    return (pick,)
+
+
+@app.cell(hide_code=True)
+async def inference(pick, runtime, sel, test_pred, x_test_np, y_test):
+    _k = pick.value if pick is not None else 0
+    _i = int(sel[_k])
+
+    # Inference runs through the cached runtime — native onnxruntime on a host,
+    # onnxruntime-web in the browser.
+    _logits = (await runtime.run({"x": x_test_np[_i : _i + 1]}, ["logits"]))[0][0]
+    _p = np.exp(_logits - _logits.max())
+    _p = _p / _p.sum()
+    _pred = int(_p.argmax())
+
+    _fig, (_ax_sig, _ax_bar) = plt.subplots(
+        1, 2, figsize=(9, 2.6), width_ratios=[1, 1.2]
+    )
+    _ax_sig.plot(x_test_np[_i], color="#2563eb")
+    _ax_sig.set_title(f"selected signal · true label {int(y_test[_i])}")
+    _ax_sig.set_axis_off()
+
+    _colors = ["#2563eb" if k == _pred else "#cbd5e1" for k in range(10)]
+    _ax_bar.bar(range(10), _p, color=_colors)
+    _ax_bar.set_xticks(range(10))
+    _ax_bar.set_title(
+        f"live ONNX prediction: {_pred} ({_p[_pred]:.0%})"
+        + ("" if _pred == int(test_pred[_i]) else " · differs from cache!")
+    )
+    _ax_bar.set_ylim(0, 1)
+    _fig.tight_layout()
+    _fig
+    return
+
+
+@app.cell(hide_code=True)
+def confusion(sel, test_pred, y_test):
+    mo.stop(
+        len(sel) < 5,
+        mo.md("*Select at least 5 points to see a confusion matrix for the region.*"),
+    )
+    import matplotlib.patches as mpatches
+
+    _yt, _yp = y_test[sel], test_pred[sel]
+    _cm = np.zeros((10, 10), int)
+    for _t, _p in zip(_yt, _yp):
+        _cm[_t, _p] += 1
+
+    _fig, _ax = plt.subplots(figsize=(4.6, 4.2))
+    _ax.imshow(_cm, cmap="Blues")
+    _ax.set_xticks(range(10))
+    _ax.set_yticks(range(10))
+    _ax.set_xlabel("predicted")
+    _ax.set_ylabel("true")
+    _ax.set_title(
+        f"confusion on selection · n={len(sel)} · acc {(_yt == _yp).mean():.0%}"
+    )
+
+    _hi = _cm.max() / 2 if _cm.max() else 1
+    for _t in range(10):
+        for _p in range(10):
+            if _cm[_t, _p]:
+                _ax.text(
+                    _p,
+                    _t,
+                    _cm[_t, _p],
+                    ha="center",
+                    va="center",
+                    color="white" if _cm[_t, _p] > _hi else "black",
+                    fontsize=8,
+                )
+    for _d in range(10):
+        _ax.add_patch(
+            mpatches.Rectangle(
+                (_d - 0.5, _d - 0.5),
+                1,
+                1,
+                fill=False,
+                edgecolor="#16a34a",
+                linewidth=2,
+            )
+        )
+    _fig.tight_layout()
+
+    mo.vstack(
+        [
+            mo.md(
+                "*The confusion matrix uses the model's cached test predictions, "
+                "which ship in the export. No per-point inference is needed.*"
+            ),
+            _fig,
+        ]
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def footer():
+    mo.md(r"""
+    ---
+    The cached value here is the `OnnxRuntime` object itself: moutils'
+    `CustomStub` stores it as exactly its ONNX bytes and restores a working
+    session on the other side of the cache — including inside a static WASM
+    export, where `onnxruntime-web` runs it in the browser.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/onnx_mnist1d.py
+++ b/notebooks/onnx_mnist1d.py
@@ -77,8 +77,6 @@ def train():
         # function and never become cached cell defs. Only the torch-free
         # results returned below are cached, and cell caching bundles them
         # into the export.
-        import io
-
         import pymde
         import torch
         from mnist1d.data import get_dataset_args, make_dataset
@@ -111,17 +109,14 @@ def train():
         test_pred = test_logits.argmax(1).numpy()
         acc = float((test_pred == y_test).mean())
 
-        buf = io.BytesIO()
-        torch.onnx.export(
+        runtime = OnnxRuntime.from_torch(
             model,
             (torch.zeros(1, 40),),
-            buf,
             input_names=["x"],
             output_names=["logits"],
             dynamic_axes={"x": {0: "n"}, "logits": {0: "n"}},
             dynamo=False,
         )
-        runtime = OnnxRuntime(buf.getvalue())
 
         mde = pymde.preserve_neighbors(
             torch.tensor(x_test_np),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = ["marimo"]
 # Database connections (moutils.db). PostHog uses `requests` (a base dep);
 # Datasette needs httpx. Install with `pip install moutils[db]`.
 db = ["httpx>=0.27"]
+# Native (non-browser) inference for moutils.onnx.OnnxRuntime. In the browser
+# the runtime loads onnxruntime-web from a CDN, so no extra is needed there.
+wasm = ["onnxruntime>=1.16.0"]
 
 # Dependency groups (recognized by `uv`). For more details, visit:
 # https://peps.python.org/pep-0735/
@@ -33,6 +36,9 @@ dev = [
   "pytest-httpx>=0.30",
   "datasette>=0.64,<1",
   "datasette-auth-tokens>=0.3,<0.4",
+  # moutils.onnx test stack
+  "onnx",
+  "onnxruntime>=1.16.0",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -167,8 +167,15 @@ class OnnxRuntime:
             feeds[name] = self._ort.Tensor.new(
                 str(arr.dtype), to_js(arr.ravel()), to_js(list(arr.shape))
             )
-        results = await self._session.run(to_js(feeds))
-        names = output_names or list(results.object_keys())
+        # Pass the requested names as `fetches` so the runtime computes only
+        # those outputs, matching the native path. Default to the session's
+        # declared outputs when none are requested.
+        names = (
+            list(output_names)
+            if output_names
+            else list(self._session.outputNames)
+        )
+        results = await self._session.run(to_js(feeds), to_js(names))
         out = []
         for name in names:
             tensor = getattr(results, name)

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -170,11 +170,7 @@ class OnnxRuntime:
         # Pass the requested names as `fetches` so the runtime computes only
         # those outputs, matching the native path. Default to the session's
         # declared outputs when none are requested.
-        names = (
-            list(output_names)
-            if output_names
-            else list(self._session.outputNames)
-        )
+        names = list(output_names) if output_names else list(self._session.outputNames)
         results = await self._session.run(to_js(feeds), to_js(names))
         out = []
         for name in names:

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -1,0 +1,158 @@
+"""A cache-friendly ONNX inference runtime for marimo notebooks.
+
+`OnnxRuntime` holds a serialized ONNX model and runs it lazily, adapting to its
+environment: native `onnxruntime` on a host, and `onnxruntime-web` (loaded from
+a CDN) when the notebook runs in the browser via WASM/pyodide.
+
+Importing this module registers a marimo cache stub, so a cached `OnnxRuntime`
+round-trips as exactly its model bytes. A torch or jax model trained at export
+time then restores as a working inference session inside a static WASM export.
+The training framework never loads in the browser. See the README section "ONNX
+runtime caching" for the notebook and export recipe.
+
+Example:
+    ```python
+    from moutils.onnx import OnnxRuntime
+
+    runtime = OnnxRuntime(onnx_bytes)          # a serialized ONNX model
+    logits = (await runtime.run({"x": x}))[0]  # x: a numpy input array
+    ```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["OnnxRuntime"]
+
+
+class OnnxRuntime:
+    """Lazy, environment-adaptive ONNX inference session.
+
+    Holds only the serialized model. The live session is built on the first
+    `run()` call and is never serialized. Pickling or caching an instance
+    round-trips just the model bytes.
+    """
+
+    def __init__(self, onnx_bytes: bytes) -> None:
+        self.onnx_bytes = onnx_bytes
+        self._session: Any = None
+        self._ort: Any = None
+        self._kind: str | None = None
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {"onnx_bytes": self.onnx_bytes}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.onnx_bytes = state["onnx_bytes"]
+        self._session = None
+        self._ort = None
+        self._kind = None
+
+    @staticmethod
+    def _in_browser() -> bool:
+        from importlib.util import find_spec
+
+        return find_spec("js") is not None and find_spec("pyodide") is not None
+
+    async def _ensure(self) -> None:
+        if self._session is not None:
+            return
+        if self._in_browser():
+            import js  # type: ignore[import-not-found]
+            from pyodide.ffi import to_js  # type: ignore[import-not-found]
+
+            ort = await js.eval(
+                "import('https://cdn.jsdelivr.net/npm/onnxruntime-web"
+                "/dist/ort.all.bundle.min.mjs')"
+            )
+            ort.env.wasm.wasmPaths = (
+                "https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/"
+            )
+            opts = js.Object.new()
+            opts.executionProviders = to_js(["wasm"])
+            self._ort = ort
+            self._session = await ort.InferenceSession.create(
+                to_js(self.onnx_bytes), opts
+            )
+            self._kind = "web"
+        else:
+            try:
+                import onnxruntime as ort
+            except ImportError as e:
+                raise RuntimeError(
+                    "OnnxRuntime.run() outside the browser requires the "
+                    "`onnxruntime` package (`pip install onnxruntime`)."
+                ) from e
+
+            self._session = ort.InferenceSession(self.onnx_bytes)
+            self._kind = "native"
+
+    async def run(
+        self,
+        inputs: dict[str, Any],
+        output_names: list[str] | None = None,
+    ) -> list[Any]:
+        """Run inference and return the outputs in `output_names` order.
+
+        Args:
+            inputs: Mapping of input name to a numpy array.
+            output_names: Names of the outputs to return, in order. When `None`,
+                returns all outputs in the session's declared order.
+        """
+        import numpy as np
+
+        await self._ensure()
+        if self._kind == "native":
+            return self._session.run(output_names, inputs)
+
+        from pyodide.ffi import to_js  # type: ignore[import-not-found]
+
+        feeds = {}
+        for name, arr in inputs.items():
+            arr = np.ascontiguousarray(arr, dtype=np.float32)
+            feeds[name] = self._ort.Tensor.new(
+                "float32", to_js(arr.ravel()), to_js(list(arr.shape))
+            )
+        results = await self._session.run(to_js(feeds))
+        names = output_names or list(results.object_keys())
+        out = []
+        for name in names:
+            tensor = getattr(results, name)
+            out.append(
+                np.asarray(tensor.data.to_py(), dtype=np.float32).reshape(
+                    list(tensor.dims.to_py())
+                )
+            )
+        return out
+
+
+# Register a marimo cache stub: caching an `OnnxRuntime` then stores exactly its
+# ONNX bytes and restores a working session. Guarded so `moutils.onnx` imports
+# without marimo — the stub is only used inside a marimo cache.
+try:
+    from marimo._save.stubs import CustomStub, register_stub
+except Exception:  # pragma: no cover - marimo not installed
+    pass
+else:
+
+    class OnnxRuntimeStub(CustomStub):
+        """Serialize an `OnnxRuntime` as exactly its model bytes."""
+
+        __slots__ = ("onnx_bytes",)
+
+        def __init__(self, runtime: Any) -> None:
+            self.onnx_bytes = runtime.onnx_bytes
+
+        def load(self, glbls: dict[str, Any]) -> Any:
+            del glbls
+            return OnnxRuntime(self.onnx_bytes)
+
+        @staticmethod
+        def get_type() -> type:
+            return OnnxRuntime
+
+        def to_bytes(self) -> bytes:
+            return self.onnx_bytes
+
+    register_stub(OnnxRuntime, OnnxRuntimeStub)

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -27,6 +27,12 @@ from typing import Any
 
 __all__ = ["OnnxRuntime"]
 
+# onnxruntime-web build loaded in the browser backend. Pinned for
+# reproducibility; override per instance via the `wasm_version` argument.
+# Tracks the current onnxruntime-web release (what the unpinned CDN URL served,
+# now made explicit). Native `onnxruntime` in the lock is 1.28.0.
+DEFAULT_WASM_VERSION = "1.27.0"
+
 
 class OnnxRuntime:
     """Lazy, environment-adaptive ONNX inference session.
@@ -36,14 +42,24 @@ class OnnxRuntime:
     round-trips just the model bytes.
     """
 
-    def __init__(self, onnx_bytes: bytes) -> None:
+    def __init__(
+        self, onnx_bytes: bytes, *, wasm_version: str = DEFAULT_WASM_VERSION
+    ) -> None:
         self.onnx_bytes = onnx_bytes
+        self.wasm_version = wasm_version
         self._session: Any = None
         self._ort: Any = None
         self._kind: str | None = None
 
     @classmethod
-    def from_torch(cls, model: Any, args: Any, **export_kwargs: Any) -> OnnxRuntime:
+    def from_torch(
+        cls,
+        model: Any,
+        args: Any,
+        *,
+        wasm_version: str = DEFAULT_WASM_VERSION,
+        **export_kwargs: Any,
+    ) -> OnnxRuntime:
         """Export a torch model to ONNX and wrap the bytes.
 
         `args` and `export_kwargs` pass through to `torch.onnx.export`.
@@ -54,10 +70,17 @@ class OnnxRuntime:
 
         buf = io.BytesIO()
         torch.onnx.export(model, args, buf, **export_kwargs)
-        return cls(buf.getvalue())
+        return cls(buf.getvalue(), wasm_version=wasm_version)
 
     @classmethod
-    def from_jax(cls, fn: Any, inputs: Any, **to_onnx_kwargs: Any) -> OnnxRuntime:
+    def from_jax(
+        cls,
+        fn: Any,
+        inputs: Any,
+        *,
+        wasm_version: str = DEFAULT_WASM_VERSION,
+        **to_onnx_kwargs: Any,
+    ) -> OnnxRuntime:
         """Convert a JAX function to ONNX and wrap the bytes.
 
         Uses [`jax2onnx`](https://pypi.org/project/jax2onnx/). `inputs` (a
@@ -67,13 +90,17 @@ class OnnxRuntime:
         from jax2onnx import to_onnx
 
         model = to_onnx(fn, inputs, **to_onnx_kwargs)
-        return cls(model.SerializeToString())
+        return cls(model.SerializeToString(), wasm_version=wasm_version)
 
     def __getstate__(self) -> dict[str, Any]:
-        return {"onnx_bytes": self.onnx_bytes}
+        return {
+            "onnx_bytes": self.onnx_bytes,
+            "wasm_version": self.wasm_version,
+        }
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.onnx_bytes = state["onnx_bytes"]
+        self.wasm_version = state.get("wasm_version", DEFAULT_WASM_VERSION)
         self._session = None
         self._ort = None
         self._kind = None
@@ -91,13 +118,9 @@ class OnnxRuntime:
             import js  # type: ignore[import-not-found]
             from pyodide.ffi import to_js  # type: ignore[import-not-found]
 
-            ort = await js.eval(
-                "import('https://cdn.jsdelivr.net/npm/onnxruntime-web"
-                "/dist/ort.all.bundle.min.mjs')"
-            )
-            ort.env.wasm.wasmPaths = (
-                "https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/"
-            )
+            base = f"https://cdn.jsdelivr.net/npm/onnxruntime-web@{self.wasm_version}"
+            ort = await js.eval(f"import('{base}/dist/ort.all.bundle.min.mjs')")
+            ort.env.wasm.wasmPaths = f"{base}/dist/"
             opts = js.Object.new()
             opts.executionProviders = to_js(["wasm"])
             self._ort = ort
@@ -139,19 +162,19 @@ class OnnxRuntime:
 
         feeds = {}
         for name, arr in inputs.items():
-            arr = np.ascontiguousarray(arr, dtype=np.float32)
+            # Preserve the caller's dtype — int64 token ids, bool masks, etc.
+            arr = np.ascontiguousarray(arr)
             feeds[name] = self._ort.Tensor.new(
-                "float32", to_js(arr.ravel()), to_js(list(arr.shape))
+                str(arr.dtype), to_js(arr.ravel()), to_js(list(arr.shape))
             )
         results = await self._session.run(to_js(feeds))
         names = output_names or list(results.object_keys())
         out = []
         for name in names:
             tensor = getattr(results, name)
+            # to_py() yields the tensor's native dtype; do not coerce it.
             out.append(
-                np.asarray(tensor.data.to_py(), dtype=np.float32).reshape(
-                    list(tensor.dims.to_py())
-                )
+                np.asarray(tensor.data.to_py()).reshape(list(tensor.dims.to_py()))
             )
         return out
 
@@ -161,21 +184,22 @@ class OnnxRuntime:
 # without marimo — the stub is only used inside a marimo cache.
 try:
     from marimo._save.stubs import CustomStub, register_stub
-except Exception:  # pragma: no cover - marimo not installed
+except ImportError:  # pragma: no cover - marimo not installed
     pass
 else:
 
     class OnnxRuntimeStub(CustomStub):
-        """Serialize an `OnnxRuntime` as exactly its model bytes."""
+        """Store an `OnnxRuntime`'s model bytes and pinned wasm version."""
 
-        __slots__ = ("onnx_bytes",)
+        __slots__ = ("onnx_bytes", "wasm_version")
 
         def __init__(self, runtime: Any) -> None:
             self.onnx_bytes = runtime.onnx_bytes
+            self.wasm_version = runtime.wasm_version
 
         def load(self, glbls: dict[str, Any]) -> Any:
             del glbls
-            return OnnxRuntime(self.onnx_bytes)
+            return OnnxRuntime(self.onnx_bytes, wasm_version=self.wasm_version)
 
         @staticmethod
         def get_type() -> type:

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -23,6 +23,7 @@ Example:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 __all__ = ["OnnxRuntime"]
@@ -32,6 +33,11 @@ __all__ = ["OnnxRuntime"]
 # Tracks the current onnxruntime-web release (what the unpinned CDN URL served,
 # now made explicit). Native `onnxruntime` in the lock is 1.28.0.
 DEFAULT_WASM_VERSION = "1.27.0"
+
+# `wasm_version` is interpolated into the browser's `js.eval` URL, so restrict
+# it to version-string characters — no quotes, whitespace, or `);` that could
+# break out of the string and inject JavaScript.
+_WASM_VERSION_RE = re.compile(r"\A[0-9A-Za-z][0-9A-Za-z._+-]*\Z")
 
 
 class OnnxRuntime:
@@ -45,6 +51,11 @@ class OnnxRuntime:
     def __init__(
         self, onnx_bytes: bytes, *, wasm_version: str = DEFAULT_WASM_VERSION
     ) -> None:
+        if not _WASM_VERSION_RE.match(wasm_version):
+            raise ValueError(
+                f"invalid wasm_version {wasm_version!r}: expected a version "
+                "string such as '1.27.0'."
+            )
         self.onnx_bytes = onnx_bytes
         self.wasm_version = wasm_version
         self._session: Any = None

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -7,18 +7,6 @@ a CDN) when the notebook runs in the browser via WASM/pyodide.
 Importing this module registers a marimo cache stub, so a cached `OnnxRuntime`
 round-trips as exactly its model bytes. A torch or jax model trained at export
 time then restores as a working inference session inside a static WASM export.
-
-Example:
-    ```python
-    from moutils.onnx import OnnxRuntime
-
-    # From a torch model (torch.onnx.export kwargs pass through):
-    runtime = OnnxRuntime.from_torch(model, (example_input,), output_names=["y"])
-    # Or wrap serialized ONNX bytes directly:
-    runtime = OnnxRuntime(onnx_bytes)
-
-    logits = (await runtime.run({"x": x}))[0]  # x: a numpy input array
-    ```
 """
 
 from __future__ import annotations
@@ -46,6 +34,23 @@ class OnnxRuntime:
     Holds only the serialized model. The live session is built on the first
     `run()` call and is never serialized. Pickling or caching an instance
     round-trips just the model bytes.
+
+    Example:
+        ```python
+        from moutils.onnx import OnnxRuntime
+
+        # Build from a trained torch model. `example_input` is a sample input
+        # tensor (any values) whose shape traces the exported graph.
+        runtime = OnnxRuntime.from_torch(
+            model, (example_input,), input_names=["x"], output_names=["y"]
+        )
+        # ...or from a JAX function, or from raw ONNX bytes:
+        runtime = OnnxRuntime.from_jax(fn, [("B", 4)], input_names=["x"])
+        runtime = OnnxRuntime(onnx_bytes)
+
+        # `run` is async; `x` is a numpy array, `y` a numpy array:
+        (y,) = await runtime.run({"x": x}, ["y"])
+        ```
     """
 
     def __init__(
@@ -71,9 +76,24 @@ class OnnxRuntime:
         wasm_version: str = DEFAULT_WASM_VERSION,
         **export_kwargs: Any,
     ) -> OnnxRuntime:
-        """Export a torch model to ONNX and wrap the bytes.
+        """Export a torch model to ONNX and wrap the resulting bytes.
 
-        `args` and `export_kwargs` pass through to `torch.onnx.export`.
+        Args:
+            model: A torch module (or callable) to export.
+            args: Example inputs that trace the graph, as a tuple — for
+                example `(torch.zeros(1, 4),)`.
+            wasm_version: onnxruntime-web version for the browser backend.
+            export_kwargs: Extra keyword arguments forwarded to
+                `torch.onnx.export`, such as `input_names`, `output_names`,
+                and `dynamo`.
+
+        Example:
+            ```python
+            runtime = OnnxRuntime.from_torch(
+                model, (torch.zeros(1, 4),),
+                input_names=["x"], output_names=["logits"],
+            )
+            ```
         """
         import io
 
@@ -92,11 +112,26 @@ class OnnxRuntime:
         wasm_version: str = DEFAULT_WASM_VERSION,
         **to_onnx_kwargs: Any,
     ) -> OnnxRuntime:
-        """Convert a JAX function to ONNX and wrap the bytes.
+        """Convert a JAX function to ONNX and wrap the resulting bytes.
 
-        Uses [`jax2onnx`](https://pypi.org/project/jax2onnx/). `inputs` (a
-        sequence of shapes) and `to_onnx_kwargs` pass through to
-        `jax2onnx.to_onnx`.
+        Uses [`jax2onnx`](https://pypi.org/project/jax2onnx/).
+
+        Args:
+            fn: A JAX-traceable function.
+            inputs: One shape per argument to `fn`, for example `[("B", 4)]`
+                for a dynamic batch of width 4.
+            wasm_version: onnxruntime-web version for the browser backend.
+            to_onnx_kwargs: Extra keyword arguments forwarded to
+                `jax2onnx.to_onnx`, such as `input_names`.
+
+        Example:
+            ```python
+            import jax.numpy as jnp
+
+            runtime = OnnxRuntime.from_jax(
+                lambda x: jnp.tanh(x), [("B", 4)], input_names=["x"]
+            )
+            ```
         """
         from jax2onnx import to_onnx
 
@@ -156,12 +191,20 @@ class OnnxRuntime:
         inputs: dict[str, Any],
         output_names: list[str] | None = None,
     ) -> list[Any]:
-        """Run inference and return the outputs in `output_names` order.
+        """Run inference and return the requested outputs, in order.
 
         Args:
-            inputs: Mapping of input name to a numpy array.
-            output_names: Names of the outputs to return, in order. When `None`,
-                returns all outputs in the session's declared order.
+            inputs: Mapping of model input name to a numpy array.
+            output_names: Model output names to return, in order. When `None`,
+                returns every output in the model's declared order.
+
+        Example:
+            ```python
+            # Ask for one named output:
+            (logits,) = await runtime.run({"x": x}, ["logits"])
+            # ...or every output:
+            outputs = await runtime.run({"x": x})
+            ```
         """
         import numpy as np
 

--- a/src/moutils/onnx.py
+++ b/src/moutils/onnx.py
@@ -7,14 +7,16 @@ a CDN) when the notebook runs in the browser via WASM/pyodide.
 Importing this module registers a marimo cache stub, so a cached `OnnxRuntime`
 round-trips as exactly its model bytes. A torch or jax model trained at export
 time then restores as a working inference session inside a static WASM export.
-The training framework never loads in the browser. See the README section "ONNX
-runtime caching" for the notebook and export recipe.
 
 Example:
     ```python
     from moutils.onnx import OnnxRuntime
 
-    runtime = OnnxRuntime(onnx_bytes)          # a serialized ONNX model
+    # From a torch model (torch.onnx.export kwargs pass through):
+    runtime = OnnxRuntime.from_torch(model, (example_input,), output_names=["y"])
+    # Or wrap serialized ONNX bytes directly:
+    runtime = OnnxRuntime(onnx_bytes)
+
     logits = (await runtime.run({"x": x}))[0]  # x: a numpy input array
     ```
 """
@@ -39,6 +41,33 @@ class OnnxRuntime:
         self._session: Any = None
         self._ort: Any = None
         self._kind: str | None = None
+
+    @classmethod
+    def from_torch(cls, model: Any, args: Any, **export_kwargs: Any) -> OnnxRuntime:
+        """Export a torch model to ONNX and wrap the bytes.
+
+        `args` and `export_kwargs` pass through to `torch.onnx.export`.
+        """
+        import io
+
+        import torch
+
+        buf = io.BytesIO()
+        torch.onnx.export(model, args, buf, **export_kwargs)
+        return cls(buf.getvalue())
+
+    @classmethod
+    def from_jax(cls, fn: Any, inputs: Any, **to_onnx_kwargs: Any) -> OnnxRuntime:
+        """Convert a JAX function to ONNX and wrap the bytes.
+
+        Uses [`jax2onnx`](https://pypi.org/project/jax2onnx/). `inputs` (a
+        sequence of shapes) and `to_onnx_kwargs` pass through to
+        `jax2onnx.to_onnx`.
+        """
+        from jax2onnx import to_onnx
+
+        model = to_onnx(fn, inputs, **to_onnx_kwargs)
+        return cls(model.SerializeToString())
 
     def __getstate__(self) -> dict[str, Any]:
         return {"onnx_bytes": self.onnx_bytes}

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -94,6 +94,21 @@ def test_from_torch_builds_runnable_model():
     assert y.shape == (1, 2)
 
 
+def test_wasm_version_pins_and_round_trips():
+    from moutils.onnx import DEFAULT_WASM_VERSION, OnnxRuntimeStub
+
+    assert OnnxRuntime(b"m").wasm_version == DEFAULT_WASM_VERSION
+    rt = OnnxRuntime(b"m", wasm_version="1.20.1")
+    assert rt.wasm_version == "1.20.1"
+    # The pin survives a pickle round-trip and the marimo cache stub.
+    import pickle
+
+    assert pickle.loads(pickle.dumps(rt)).wasm_version == "1.20.1"
+    restored = OnnxRuntimeStub(rt).load({})
+    assert restored.wasm_version == "1.20.1"
+    assert restored.onnx_bytes == b"m"
+
+
 def test_from_jax_builds_runnable_model():
     pytest.importorskip("jax")
     pytest.importorskip("jax2onnx")

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -109,6 +109,13 @@ def test_wasm_version_pins_and_round_trips():
     assert restored.onnx_bytes == b"m"
 
 
+def test_wasm_version_rejects_injection():
+    OnnxRuntime(b"m", wasm_version="1.27.0")  # a valid version does not raise
+    for bad in ["1.0'); alert(1); //", "1 2", 'a"b', "x)", "v/../../etc"]:
+        with pytest.raises(ValueError):
+            OnnxRuntime(b"m", wasm_version=bad)
+
+
 def test_from_jax_builds_runnable_model():
     pytest.importorskip("jax")
     pytest.importorskip("jax2onnx")

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -76,6 +76,41 @@ def test_native_run_defaults_to_all_outputs():
     np.testing.assert_array_equal(outputs[0], 2 * x)
 
 
+def test_from_torch_builds_runnable_model():
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("onnxruntime")
+    model = torch.nn.Linear(3, 2)
+    rt = OnnxRuntime.from_torch(
+        model,
+        (torch.zeros(1, 3),),
+        input_names=["x"],
+        output_names=["y"],
+        dynamo=False,
+    )
+    assert isinstance(rt.onnx_bytes, bytes)
+    assert rt.onnx_bytes
+    x = np.zeros((1, 3), dtype=np.float32)
+    (y,) = asyncio.run(rt.run({"x": x}, ["y"]))
+    assert y.shape == (1, 2)
+
+
+def test_from_jax_builds_runnable_model():
+    pytest.importorskip("jax")
+    pytest.importorskip("jax2onnx")
+    pytest.importorskip("onnxruntime")
+    import jax.numpy as jnp
+
+    def fn(x):
+        return jnp.tanh(x) * 2.0
+
+    rt = OnnxRuntime.from_jax(fn, [("B", 3)], input_names=["x"])
+    assert isinstance(rt.onnx_bytes, bytes)
+    assert rt.onnx_bytes
+    x = np.ones((1, 3), dtype=np.float32)
+    (y,) = asyncio.run(rt.run({"x": x}))
+    np.testing.assert_allclose(y, np.tanh(1.0) * 2.0, rtol=1e-4)
+
+
 def test_marimo_cache_conversion():
     # Exercise marimo's real save/restore path: maybe_get_custom_stub routes an
     # OnnxRuntime to its stub, which restores just the model bytes, no session.

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,0 +1,89 @@
+"""Tests for the OnnxRuntime cache stub."""
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from moutils.onnx import OnnxRuntime
+
+
+def test_import_and_bytes():
+    rt = OnnxRuntime(b"model-bytes")
+    assert rt.onnx_bytes == b"model-bytes"
+    # Session builds lazily. Construction does nothing heavy.
+    assert rt._session is None
+
+
+def test_stub_registered():
+    from marimo._save.stubs import CUSTOM_STUBS
+
+    assert OnnxRuntime in CUSTOM_STUBS
+
+
+def test_stub_serializes_to_model_bytes():
+    from moutils.onnx import OnnxRuntimeStub
+
+    stub = OnnxRuntimeStub(OnnxRuntime(b"abc"))
+    assert stub.to_bytes() == b"abc"
+    restored = stub.load({})
+    assert isinstance(restored, OnnxRuntime)
+    assert restored.onnx_bytes == b"abc"
+    assert restored._session is None
+
+
+def test_pickle_roundtrip_keeps_only_bytes():
+    import pickle
+
+    rt = OnnxRuntime(b"payload")
+    rt._session = object()  # a live session must never be serialized
+    restored = pickle.loads(pickle.dumps(rt))
+    assert restored.onnx_bytes == b"payload"
+    assert restored._session is None
+
+
+def _double_model_bytes() -> bytes:
+    # Minimal ONNX model: y = x + x, so run() output should be 2*x.
+    pytest.importorskip("onnx")
+    from onnx import TensorProto, helper
+
+    node = helper.make_node("Add", ["x", "x"], ["y"])
+    graph = helper.make_graph(
+        [node],
+        "double",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, [None, 2])],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT, [None, 2])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    return model.SerializeToString()
+
+
+def test_native_run_executes_model():
+    pytest.importorskip("onnxruntime")
+    rt = OnnxRuntime(_double_model_bytes())
+    x = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    (y,) = asyncio.run(rt.run({"x": x}, ["y"]))
+    np.testing.assert_array_equal(y, 2 * x)
+    assert rt._kind == "native"
+
+
+def test_native_run_defaults_to_all_outputs():
+    pytest.importorskip("onnxruntime")
+    rt = OnnxRuntime(_double_model_bytes())
+    x = np.array([[5.0, 6.0]], dtype=np.float32)
+    outputs = asyncio.run(rt.run({"x": x}))  # output_names=None
+    assert len(outputs) == 1
+    np.testing.assert_array_equal(outputs[0], 2 * x)
+
+
+def test_marimo_cache_conversion():
+    # Exercise marimo's real save/restore path: maybe_get_custom_stub routes an
+    # OnnxRuntime to its stub, which restores just the model bytes, no session.
+    from marimo._save.stubs import maybe_get_custom_stub
+
+    stub = maybe_get_custom_stub(OnnxRuntime(b"trained-model-bytes"))
+    assert stub is not None
+    restored = stub.load({})
+    assert isinstance(restored, OnnxRuntime)
+    assert restored.onnx_bytes == b"trained-model-bytes"
+    assert restored._session is None

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "aiofiles"
@@ -263,6 +267,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -710,8 +722,44 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
 name = "moutils"
-version = "0.4.4"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },
@@ -725,6 +773,9 @@ db = [
 dev = [
     { name = "marimo" },
 ]
+wasm = [
+    { name = "onnxruntime" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -732,6 +783,8 @@ dev = [
     { name = "datasette-auth-tokens" },
     { name = "httpx" },
     { name = "marimo" },
+    { name = "onnx" },
+    { name = "onnxruntime" },
     { name = "pytest" },
     { name = "pytest-httpx" },
     { name = "responses" },
@@ -742,9 +795,10 @@ requires-dist = [
     { name = "anywidget", specifier = ">=0.9.0" },
     { name = "httpx", marker = "extra == 'db'", specifier = ">=0.27" },
     { name = "marimo", marker = "extra == 'dev'" },
+    { name = "onnxruntime", marker = "extra == 'wasm'", specifier = ">=1.16.0" },
     { name = "requests", specifier = ">=2.0.0" },
 ]
-provides-extras = ["dev", "db"]
+provides-extras = ["dev", "db", "wasm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -752,6 +806,8 @@ dev = [
     { name = "datasette-auth-tokens", specifier = ">=0.3,<0.4" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "marimo" },
+    { name = "onnx" },
+    { name = "onnxruntime", specifier = ">=1.16.0" },
     { name = "pytest" },
     { name = "pytest-httpx", specifier = ">=0.30" },
     { name = "responses", specifier = ">=0.25" },
@@ -804,6 +860,115 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6f/713be67779028d482c6e0f2dde5bc430021b2578a4808c1c9f6d7ad48257/narwhals-2.16.0.tar.gz", hash = "sha256:155bb45132b370941ba0396d123cf9ed192bf25f39c4cea726f2da422ca4e145", size = 618268, upload-time = "2026-02-02T10:31:00.545Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/cc/7cb74758e6df95e0c4e1253f203b6dd7f348bf2f29cf89e9210a2416d535/narwhals-2.16.0-py3-none-any.whl", hash = "sha256:846f1fd7093ac69d63526e50732033e86c30ea0026a44d9b23991010c7d1485d", size = 443951, upload-time = "2026-02-02T10:30:58.635Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "onnx"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/8ea73a64b368b75fe339771a20a02bc61ea1f551484c9e3d9d0bfbd0450f/onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0", size = 12024721, upload-time = "2026-06-15T12:50:05.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/6a/481561f1093834376ed493e4ca42a73e5be0d50031f2969c86593bdc7c96/onnx-1.22.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:596fbf0490947533c1c1045ba860851dc9fb77471023dac9a71ba5b42ceab103", size = 20167081, upload-time = "2026-06-15T12:49:32.078Z" },
+    { url = "https://files.pythonhosted.org/packages/84/55/b34fc2aa30aa54b4a775402d24c4082242c720283a274fe976ac8eb94480/onnx-1.22.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae5a563f281cd9d2845622cecf6c092a57e4ee1b138f66fdbbdd4200567a5e16", size = 18889249, upload-time = "2026-06-15T12:49:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a6/bd32357e6cc1ecb473afd78193d7231724f284435d2db25696ecfaaa1503/onnx-1.22.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:955e02e1f6d385b53d52f9cd7b9cdf5caf417c300bcfe3c64c6d542be763845b", size = 19106514, upload-time = "2026-06-15T12:49:37.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9d/3af461ac6c714b8b369cb71499659932f4f12cfb066250b62f7567c3d530/onnx-1.22.0-cp312-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:82e9f27fc1223cb06d68a56bed6f9d3caf3d0dad1b61bce45006d529b15bd94c", size = 16966387, upload-time = "2026-06-15T12:49:40.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f0/68195b5e5a53e333faf2660f5352ee43738d0e42fc5216cc6b1871a9fbfb/onnx-1.22.0-cp312-abi3-win32.whl", hash = "sha256:cc8b66b312f8f03a53e268afb67180a2d97dd12cc79e2b61361c6c0073448016", size = 17081568, upload-time = "2026-06-15T12:49:43.398Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a8/734725bb703c5fabb687f79c79e51249475212b3eb37771ac4a4ac9b487f/onnx-1.22.0-cp312-abi3-win_amd64.whl", hash = "sha256:72ccebab3bac07215c204ce8848d42e78eaaa666badbf72d25cd359b9f269e3a", size = 17213290, upload-time = "2026-06-15T12:49:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/8ce48d8ae26a8761ad4e5dc771961b155c5c3c7c8540ec7f2f2d71b69af0/onnx-1.22.0-cp312-abi3-win_arm64.whl", hash = "sha256:f3c120dcdb70ad738f3c061b32798f408ea299eb69f84dd69ab4a6bf3c2ec01f", size = 17207030, upload-time = "2026-06-15T12:49:48.635Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/13/47323b97846387848efb1044ded11bb94b83526f3d1fbdb37c6480d4520f/onnx-1.22.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:19e45e4af88e3fe3261458d4b8cc461957ae2782a358a3560503569bf3b23b72", size = 20176465, upload-time = "2026-06-15T12:49:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0c/d3b8a7e7eee123938586c608bb9894b5723f2342b9450c0eec59fbec7099/onnx-1.22.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c21a0e59fd967a95b358e4a6e756d1f1eec2d304a83480f329f66e30d2bf0223", size = 18894028, upload-time = "2026-06-15T12:49:54.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8a/da2a97ab46fe6e0cd9beb3ac14603a22f5be492f9ca347faf8233a07bb33/onnx-1.22.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2632406b8f523ef2e2873c363f90b20a3d88c0fbcfac757d3addffccf8f452c2", size = 19110420, upload-time = "2026-06-15T12:49:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/ce984063017518307ebfaa545782fc400e593dc2d7fdf4f23ce4be1ed197/onnx-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a3a39fc4643867aecb33417fdddb11e308ee79d2d4a584b9d50cc7aec2091b13", size = 17237547, upload-time = "2026-06-15T12:50:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/257a880384a1dd502d543b0067945074d63cd17d0840e958355bc8197da8/onnx-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:8e268cdc0547e3949799ffd4a44451dc2b9080b57d0824a2db680b6ec65506f0", size = 17231391, upload-time = "2026-06-15T12:50:03.047Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/952314c451d9463e5c9aed9978eec76cf32930d407d9ab8700dd0f4ea1ea/onnxruntime-1.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:8adff67a3f28257b37cfe945a7e952e4122666aa8c91a0380862e9fd4c2ed19f", size = 19143748, upload-time = "2026-07-25T01:21:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/139180b4dd810329aaa42c238b4e6383c906202d98609ae29d66eb7c32b1/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2565e487b4896fb988d6383577d875d958e071fc5f6c3550bd5d02ae98264b", size = 17051950, upload-time = "2026-07-25T01:21:48.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/88/9432428273356ad3c8aa01f52c1b3e7f53c4c0192748f41ad983872b436b/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6afdc83f1317c136e92fc29f5ee9f058de59d87c0b22cee3fdbfbaa0ccc2098a", size = 19214924, upload-time = "2026-07-25T01:22:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e2/6feb3a43517aaf2b1bf7e46897ba5eb81a29717f7d7901420614d5ee4653/onnxruntime-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2a3b9e30ce880d4ca54999cb313569e36da4f62eefe25f87be18f43e9a3a4d5", size = 14093738, upload-time = "2026-07-25T01:22:31.629Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8f/83974a1e201dc2e58e5e7111bcaeb1ca2413e9c41f505d26419ee9e3dddf/onnxruntime-1.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:07fb3cbe990d6bf0ab3c22bfbbfb0e314151266046ea6edb4a07f556b4258c5f", size = 13821117, upload-time = "2026-07-25T01:22:22.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/83/00e606bc25c756d76a267370c39b7516ad52f9cf134d7ff2bff8b6108bc4/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af", size = 17055518, upload-time = "2026-07-25T01:21:51.08Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a9/68707e1ce345cbdbcd4df65932ebc82a673e917d63eda0007ebcff948691/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e", size = 19222976, upload-time = "2026-07-25T01:22:12.474Z" },
 ]
 
 [[package]]
@@ -892,6 +1057,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds a ONNX runtime adapter for `jax` and `pytorch` models such that they can run inference over WASM.

Example:

```python
from moutils.onnx import OnnxRuntime

runtime = OnnxRuntime.from_torch(model, (example_input,), output_names=["y"])
runtime = OnnxRuntime.from_jax(fn, [("B", 4)], input_names=["x"])  # via jax2onnx
runtime = OnnxRuntime(onnx_bytes)                                  # low-level

logits = (await runtime.run({"x": x}, ["y"]))[0]   # async; picks the backend
```
## Also included

- `notebooks/onnx_mnist1d.py` end-to-end example (MLP trained on MNIST-1D, cached as an OnnxRuntime, lasso-driven live inference), verified to export and restore torch-free in a WASM build.
- `README` update for an "ONNX runtime adapter" section documenting the required pattern.

## Installation

```shell
pip install "moutils[wasm]"
```

The module lazily imports all external dependencies, and has some basics handling for WASM vs native runtimes.